### PR TITLE
Expose identity on AuthenticatedRequest

### DIFF
--- a/module/src/main/scala/com/gu/googleauth/actions.scala
+++ b/module/src/main/scala/com/gu/googleauth/actions.scala
@@ -22,7 +22,7 @@ object UserIdentity {
   def fromRequest(request: Request[Any]): Option[UserIdentity] = fromRequestHeader(request)
 }
 
-class AuthenticatedRequest[A](val identity: Option[UserIdentity], request: Request[A]) extends WrappedRequest[A](request) {
+class AuthenticatedRequest[A](identity: Option[UserIdentity], request: Request[A]) extends WrappedRequest[A](request) {
   lazy val isAuthenticated = identity.isDefined
 }
 


### PR DESCRIPTION
It is handy to be able to receive the `UserIdentity` object through `AuthenticatedRequest` instead of having to take it out of the request twice using `UserIdentity.fromRequestHeader`; once to check Auth and again if you need it.

This exposes `identity` so that `Actions` get access it in their block.

I have also thought about changing `AuthenticatedRequest.isAuthenticated` to `identity.exists(_.isValid)`, but I am unsure if the way it is done now was intentionally avoiding `UserIdentity.isValid`.
