### PR TITLE
Add Auth Filter

### DIFF
--- a/module/src/main/scala/com/gu/googleauth/filters.scala
+++ b/module/src/main/scala/com/gu/googleauth/filters.scala
@@ -1,5 +1,6 @@
 package com.gu.googleauth
 
+import play.Play
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Filter, RequestHeader, Result}
 import scala.concurrent.Future
@@ -15,7 +16,7 @@ object GoogleAuthFilters {
     def apply(nextFilter: (RequestHeader) => Future[Result])
              (requestHeader: RequestHeader): Future[Result] = {
 
-      if (requestHeader.path.startsWith(loginUrl.path) ||
+      if (Play.isTest || requestHeader.path.startsWith(loginUrl.path) ||
         exemptions.exists(exemption => requestHeader.path.startsWith(exemption.path)))
         nextFilter(requestHeader)
       else {


### PR DESCRIPTION
We would like to use authentication project wide in certain projects without being explicit on each endpoint that it needs auth (via an `Action`) or being able to add auth on top of something that doesn't have it through an `Action`.

This adds `AuthFilterWithExemptions` and allows you to pick the `login` exemption explicitly and also any other exemptions that you mean need such as assets.
