### PR TITLE
Fix regression for checking validity of login (play2.2.x)

### DIFF
--- a/example/app/controllers/Login.scala
+++ b/example/app/controllers/Login.scala
@@ -9,6 +9,7 @@ import org.joda.time.Duration
 
 trait AuthActions extends Actions {
   val loginTarget: Call = routes.Login.loginAction()
+  val authConfig = Login.googleAuthConfig
 }
 
 object Login extends Controller with AuthActions {
@@ -20,8 +21,9 @@ object Login extends Controller with AuthActions {
       "http://localhost:9000/oauth2callback",      // The redirect URL Google send users back to (must be the same as
                                                    //    that configured in the developer console)
       Some("guardian.co.uk"),                      // Google App domain to restrict login
-      Some(Duration.standardHours(1))              // Force the user to re-enter their credentials if they haven't done
+      Some(Duration.standardHours(1)),             // Force the user to re-enter their credentials if they haven't done
                                                    //    so in the last hour (this is stupid unless you are testing :)
+      true                                         // Re-authenticate (without prompting) with google when session expires
     )
 
   // this is the only place we use LoginAuthAction - to prevent authentication redirect loops

--- a/example/app/views/authenticated.scala.html
+++ b/example/app/views/authenticated.scala.html
@@ -1,4 +1,5 @@
 @(request: play.api.mvc.Security.AuthenticatedRequest[AnyContent, com.gu.googleauth.UserIdentity], error: Option[String] = None)
+@import org.joda.time.DateTime
 
 <html>
     <head><title>Authorised</title></head>
@@ -7,6 +8,7 @@
         <p>This is an authorised page of the example application.</p>
         <p>It uses an AuthAction so will always have a user.</p>
         <p>In this case the logged in user is @request.user</p>
+        <p>The expiry time is @{new DateTime(request.user.exp*1000)}</p>
         <p>You can go to the <a href="@routes.Login.login()">login page</a>,
             a <a href="@routes.Application.authenticated()">page that requires authentication</a>
             or <a href="@routes.Login.logout()">logout</a>.</p>

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -4,7 +4,7 @@ name := "play-googleauth-example"
 
 scalaVersion := "2.10.4"
 
-version := "0.0.6"
+version := "0.0.7"
 
 playScalaSettings
 

--- a/module/src/main/scala/com/gu/googleauth/actions.scala
+++ b/module/src/main/scala/com/gu/googleauth/actions.scala
@@ -34,6 +34,11 @@ trait Actions {
   val LOGIN_ORIGIN_KEY = "loginOriginUrl"
 
   /**
+   * The configuration to use for these actions
+   */
+  def authConfig: GoogleAuthConfig
+
+  /**
    * The target that should be redirected to in order to carry out authentication
    */
   def loginTarget: Call
@@ -48,10 +53,16 @@ trait Actions {
     }
 
   /**
+   * Helper method that deals with getting a user identity from a request and establishing validity
+   */
+  private def userIdentity(request:RequestHeader) =
+    UserIdentity.fromRequest(request).filter(_.isValid || !authConfig.enforceValidity)
+
+  /**
    * This action ensures that the user is authenticated and their token is valid. Is a user is not logged in or their
    * token has expired then they will be authenticated.
    *
    * The AuthenticatedRequest will always have an identity.
    */
-  object AuthAction extends AuthenticatedBuilder(r => UserIdentity.fromRequest(r), r => sendForAuth(r))
+  object AuthAction extends AuthenticatedBuilder(r => userIdentity(r), r => sendForAuth(r))
 }

--- a/module/src/main/scala/com/gu/googleauth/auth.scala
+++ b/module/src/main/scala/com/gu/googleauth/auth.scala
@@ -10,12 +10,22 @@ import java.math.BigInteger
 import java.security.SecureRandom
 import org.joda.time.Duration
 
+/**
+ * The configuration class for Google authentication
+ * @param clientId The ClientID from the developer dashboard
+ * @param clientSecret The client secret from the developer dashboard
+ * @param redirectUrl The URL to return to after authentication has completed
+ * @param domain An optional domain to restrict login to (e.g. guardian.co.uk)
+ * @param maxAuthAge An optional duration after which you want a user to be prompted for their password again
+ * @param enforceValidity A boolean indicating whether you want a user to be re-authenticated when their session expires
+ */
 case class GoogleAuthConfig(
   clientId: String,
   clientSecret: String,
   redirectUrl: String,
   domain: Option[String],
-  maxAuthAge: Option[Duration] = None)
+  maxAuthAge: Option[Duration] = None,
+  enforceValidity: Boolean = true)
 
 class GoogleAuthException(val message: String, val throwable: Throwable = null) extends Exception(message, throwable)
 
@@ -48,7 +58,8 @@ object GoogleAuth {
   }
 
   def redirectToGoogle(config: GoogleAuthConfig, antiForgeryToken: String)
-                      (implicit context: ExecutionContext): Future[SimpleResult] = {
+                      (implicit request:RequestHeader, context: ExecutionContext): Future[SimpleResult] = {
+    val userIdentity = UserIdentity.fromRequest(request)
     val queryString: Map[String, Seq[String]] = Map(
       "client_id" -> Seq(config.clientId),
       "response_type" -> Seq("code"),
@@ -56,7 +67,8 @@ object GoogleAuth {
       "redirect_uri" -> Seq(config.redirectUrl),
       "state" -> Seq(antiForgeryToken)) ++
       config.domain.map(domain => "hd" -> Seq(domain)) ++
-      config.maxAuthAge.map(age => "max_auth_age" -> Seq(s"${age.getStandardSeconds}"))
+      config.maxAuthAge.map(age => "max_auth_age" -> Seq(s"${age.getStandardSeconds}")) ++
+      userIdentity.map(_.email).map("login_hint" -> Seq(_))
 
     discoveryDocument.map(dd => Redirect(s"${dd.authorization_endpoint}", queryString))
   }


### PR DESCRIPTION
Unfortunately a regression was introduced which means that sessions are not automatically re-validated when the session expires (according to the expiry time provided by Google). This fixes that and also provides the `login_hint` e-mail address to avoid the account chooser on re-auth.

Note that this might break applications with AJAX endpoints as calls within JS will not follow the redirect correctly. The workflow project has a way around this - speak to @steppenwells if interested. Alternatively you can relax the requirement to re-authenticate by setting the `enforceValidity` parameter in your `GoogleAuthConfig` to `false`.
