### PR TITLE
Replace GoogleGroupChecker implementation with the Directory API

### DIFF
--- a/module/build.sbt
+++ b/module/build.sbt
@@ -19,6 +19,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % "2.3.0" % "provided",
   "com.typesafe.play" %% "play-ws" % "2.3.0" % "provided",
   "commons-codec" % "commons-codec" % "1.9",
+  "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev53-1.20.0",
   "com.google.gdata" % "core" % "1.47.1"
 )
 


### PR DESCRIPTION
Google have discontinued the Provisioning API the GoogleGroupChecker used to work out which Google Groups the user is in - the Directory API is the replacement.

Implementation is taken from https://github.com/guardian/membership-frontend/pull/496

cc @dominickendrick 