### PR TITLE
Play 2.4 final

### DIFF
--- a/module/build.sbt
+++ b/module/build.sbt
@@ -16,8 +16,8 @@ crossScalaVersions := Seq("2.10.5", scalaVersion.value)
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play" % "2.3.8" % "provided",
-  "com.typesafe.play" %% "play-ws" % "2.3.8" % "provided",
+  "com.typesafe.play" %% "play" % "2.4.0" % "provided",
+  "com.typesafe.play" %% "play-ws" % "2.4.0" % "provided",
   "commons-codec" % "commons-codec" % "1.9",
   "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev53-1.20.0",
   "com.google.gdata" % "core" % "1.47.1"

--- a/module/version.sbt
+++ b/module/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.2-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
Now that Play 2.4 is out, make that master (I've pushed up a play-2.3.x branch). 

Note that Play 2.4 requires Java 8, so laggards will need to get on that bandwagon to use it.