### PR TITLE
Add prompt to authentication request

### DIFF
--- a/module/src/main/scala/com/gu/googleauth/auth.scala
+++ b/module/src/main/scala/com/gu/googleauth/auth.scala
@@ -19,6 +19,8 @@ import org.joda.time.Duration
  * @param domain An optional domain to restrict login to (e.g. guardian.co.uk)
  * @param maxAuthAge An optional duration after which you want a user to be prompted for their password again
  * @param enforceValidity A boolean indicating whether you want a user to be re-authenticated when their session expires
+ * @param prompt An optional space delimited, case sensitive list of ASCII string values that specifies whether the
+ *               Authorization Server prompts the End-User for reauthentication and consent
  */
 case class GoogleAuthConfig(
   clientId: String,

--- a/module/src/main/scala/com/gu/googleauth/auth.scala
+++ b/module/src/main/scala/com/gu/googleauth/auth.scala
@@ -26,7 +26,8 @@ case class GoogleAuthConfig(
   redirectUrl: String,
   domain: Option[String],
   maxAuthAge: Option[Duration] = None,
-  enforceValidity: Boolean = true)
+  enforceValidity: Boolean = true,
+  prompt: Option[String] = None)
 
 class GoogleAuthException(val message: String, val throwable: Throwable = null) extends Exception(message, throwable)
 
@@ -76,6 +77,7 @@ object GoogleAuth {
       "state" -> Seq(antiForgeryToken)) ++
       config.domain.map(domain => "hd" -> Seq(domain)) ++
       config.maxAuthAge.map(age => "max_auth_age" -> Seq(s"${age.getStandardSeconds}")) ++
+      config.prompt.map(prompt => "prompt" -> Seq(prompt)) ++
       userIdentity.map(_.email).map("login_hint" -> Seq(_))
 
     discoveryDocument(ws).map(dd => Redirect(s"${dd.authorization_endpoint}", queryString))

--- a/module/version.sbt
+++ b/module/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.2-SNAPSHOT"
+version in ThisBuild := "0.3.3-SNAPSHOT"


### PR DESCRIPTION
OpenID Connect allows an additional parameter "prompt" to be set on authentication requests.  This specifies whether the Authorization Server prompts the End-User for reauthentication and consent.

Supported values include, none, consent, login, select_account.

(http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)