### PR TITLE
Add a 'requireGroup' filter that checks Google Group membership

### DIFF
--- a/example/app/controllers/Application.scala
+++ b/example/app/controllers/Application.scala
@@ -1,8 +1,19 @@
 package controllers
 
+import com.gu.googleauth
+import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc.{Action, Controller}
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object Application extends Controller with AuthActions {
+  type GoogleAuthRequest[A] = AuthenticatedRequest[A, googleauth.UserIdentity]
+
   def index = Action { request => Ok(views.html.index(request)) }
+
   def authenticated = AuthAction { request => Ok(views.html.authenticated(request)) }
+
+  def authenticatedAndInGroup = (AuthAction andThen requireGroup[GoogleAuthRequest](includedGroups = Set("membership.dev@guardian.co.uk"))) {
+    request => Ok(views.html.authenticated(request))
+  }
 }

--- a/example/app/controllers/Login.scala
+++ b/example/app/controllers/Login.scala
@@ -8,9 +8,10 @@ import com.gu.googleauth._
 import play.api.Play.current
 import org.joda.time.Duration
 
-trait AuthActions extends Actions {
+trait AuthActions extends Actions with Filters {
   val loginTarget: Call = routes.Login.loginAction()
   val authConfig = Login.googleAuthConfig
+  lazy val groupChecker = new GoogleGroupChecker(???) // Can't share these credentials!
 }
 
 object Login extends Controller with AuthActions {

--- a/example/app/views/index.scala.html
+++ b/example/app/views/index.scala.html
@@ -6,7 +6,8 @@
         <h1>Home page</h1>
         <p>This is the home page of the example application.</p>
         <p>You can go to the <a href="@routes.Login.login()">login page</a>,
-            a <a href="@routes.Application.authenticated()">page that requires authentication</a>
+            a <a href="@routes.Application.authenticated()">page that requires authentication</a>,
+            a <a href="@routes.Application.authenticatedAndInGroup()">page that requires authentication <em>and</em> Google Group membership</a> (NB. requires GoogleServiceAccount credentials to be configured!)
             or <a href="@routes.Login.logout()">logout</a>.</p>
     </body>
 </html>

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,6 +1,6 @@
 name := "play-googleauth-example"
 
-version := "0.3.3"
+version := "0.3.5-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/example/conf/routes
+++ b/example/conf/routes
@@ -1,5 +1,6 @@
 GET        /                      controllers.Application.index
 GET        /authenticated         controllers.Application.authenticated
+GET        /authenticatedGroup    controllers.Application.authenticatedAndInGroup
 
 GET        /login                 controllers.Login.login
 GET        /loginAction           controllers.Login.loginAction

--- a/module/src/main/scala/com/gu/googleauth/actions.scala
+++ b/module/src/main/scala/com/gu/googleauth/actions.scala
@@ -77,6 +77,13 @@ trait Actions extends UserIdentifier {
 trait Filters extends UserIdentifier {
   def groupChecker: GoogleGroupChecker
 
+  /**
+    * This action ensures that the user is authenticated and has membership of *at least one* of the
+    * specified groups. If you want to ensure membership of multiple groups, you can chain multiple
+    * requireGroup() filters together.
+    *
+    * @param includedGroups if the user is a member of any one of these groups, they are allowed through
+    */
   def requireGroup[R[_] <: RequestHeader](
     includedGroups: Set[String],
     notInValidGroup: R[_] => Result = (_: R[_])  => Forbidden


### PR DESCRIPTION
I've included an updated example to show how to use the filter, this is the core bit:

```
type GoogleAuthRequest[A] = AuthenticatedRequest[A, googleauth.UserIdentity]

def authenticatedAndInGroup = (AuthAction andThen requireGroup[GoogleAuthRequest](includedGroups = Set("membership.dev@guardian.co.uk"))) {
  request => Ok(views.html.authenticated(request))
}
```

Note that I _haven't_ configured an example `GoogleServiceAccount`, as those credentials would allow anyone to read Guardian Google Group membership!

This code is taken from membership-frontend, where we quite often have a request type which isn't just a `AuthenticatedRequest[A, googleauth.UserIdentity]` (for instance, it might contain Membership data!)- so I've had to do a bit of refactoring (introducing `UserIdentifier`) so that the filter can find out the user's
identity using the `userIdentity()` method, not by taking it from `Request` object (which may not be a `AuthenticatedRequest`, or directly contain a `googleauth.UserIdentity`).

cc @sihil @cb372 (finally got the types working with a type alias)