### PR TITLE
Fix awful guava-jdk5 dependency introduced by Google Directory API client

### DIFF
--- a/module/build.sbt
+++ b/module/build.sbt
@@ -1,4 +1,5 @@
 import ReleaseTransformations._
+import Dependencies._
 
 name               := "play-googleauth"
 
@@ -11,12 +12,11 @@ crossScalaVersions := Seq("2.10.6", scalaVersion.value)
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play" % "2.4.0" % "provided",
-  "com.typesafe.play" %% "play-ws" % "2.4.0" % "provided",
-  "commons-codec" % "commons-codec" % "1.9",
-  "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev53-1.20.0",
-  "com.google.gdata" % "core" % "1.47.1"
-)
+  play,
+  playWS,
+  commonsCodec,
+  googleDataAPI
+) ++ googleDirectoryAPI
 
 scalacOptions ++= Seq("-feature", "-deprecation")
 

--- a/module/project/Dependencies.scala
+++ b/module/project/Dependencies.scala
@@ -1,0 +1,38 @@
+import sbt._
+
+/**
+  * This dependencies file is a pattern taken from Rule #2 of 'Effective SBT' by Josh Suereth:
+  * https://docs.google.com/presentation/d/15gmGLiD4Eiyx8e5Kg2eXge5wD80DF6lLG8hSqc6ohmo/edit?usp=sharing
+  *
+  * It's useful on multi-module projects, but here I'm really using it to give myself more room to document
+  * the trickier dependencies.
+  */
+object Dependencies {
+
+  //versions
+
+  val playVersion = "2.4.0"
+
+
+  //libraries
+
+  val play = "com.typesafe.play" %% "play" % playVersion
+  val playWS = "com.typesafe.play" %% "play-ws" % playVersion
+
+  val commonsCodec = "commons-codec" % "commons-codec" % "1.9"
+
+  val googleDataAPI = "com.google.gdata" % "core" % "1.47.1"
+
+  /** The google-api-services-admin-directory artifact has a transitive dependency on com.google.guava:guava-jdk5 - a
+    * nasty artifact that clashes with the regular com.google.guava:guava artifact, providing two versions of the same
+    * classes on your class path! To prevent problems, we specifically exclude this evil artifact, and ensure we have
+    * regular guava available.
+    *
+    * @see https://github.com/guardian/subscriptions-frontend/pull/363#issuecomment-186190081
+    */
+  val googleDirectoryAPI = Seq(
+    "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev53-1.20.0" exclude("com.google.guava", "guava-jdk5"),
+    "com.google.guava" % "guava" % "19.0"
+  )
+
+}


### PR DESCRIPTION
The google-api-services-admin-directory artifact has a transitive dependency on com.google.guava:guava-jdk5 - a nasty artifact that clashes with the regular com.google.guava:guava artifact, providing two versions of the same classes on your classpath! To prevent problems, we specifically exclude this evil artifact, and ensure we have regular guava available.

See also:

https://github.com/guardian/subscriptions-frontend/pull/363#issuecomment-186190081
http://stackoverflow.com/questions/25792398/gradle-transitive-dependency-exclusion-is-not-working-as-expected-how-do-i-get

cc @cb372 @rrees 