### PR TITLE
Play 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,17 @@ It can also be used to get information about the groups of your Google Apps Doma
 Versions
 --------
 
-For Play 2.4.x use the master branch [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/play-googleauth_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/play-googleauth_2.11):
+For Play 2.5.x use version 0.4.x [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/play-googleauth_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/play-googleauth_2.11):
 ```
-libraryDependencies += "com.gu" %% "play-googleauth" % "0.3.3"
+libraryDependencies += "com.gu" %% "play-googleauth" % "0.4.0"
 ```
 
-For Play 2.3.x use the `play2.3.x` branch:
+For Play 2.4.x use version 0.3.x (`play-2.4.x` branch)
+```
+libraryDependencies += "com.gu" %% "play-googleauth" % "0.3.7"
+```
+
+For Play 2.3.x use version 0.2.x (`play-2.3.x` branch):
 ```
 libraryDependencies += "com.gu" %% "play-googleauth" % "0.2.2"
 ```

--- a/example/app/controllers/Application.scala
+++ b/example/app/controllers/Application.scala
@@ -1,12 +1,13 @@
 package controllers
 
+import javax.inject.Inject
 import com.gu.googleauth
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc.{Action, Controller}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object Application extends Controller with AuthActions {
+class Application @Inject() extends Controller with AuthActions {
   type GoogleAuthRequest[A] = AuthenticatedRequest[A, googleauth.UserIdentity]
 
   def index = Action { request => Ok(views.html.index(request)) }

--- a/example/app/controllers/Application.scala
+++ b/example/app/controllers/Application.scala
@@ -1,13 +1,12 @@
 package controllers
 
-import javax.inject.Inject
 import com.gu.googleauth
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc.{Action, Controller}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class Application @Inject() extends Controller with AuthActions {
+class Application extends Controller with AuthActions {
   type GoogleAuthRequest[A] = AuthenticatedRequest[A, googleauth.UserIdentity]
 
   def index = Action { request => Ok(views.html.index(request)) }

--- a/example/app/controllers/Login.scala
+++ b/example/app/controllers/Login.scala
@@ -1,21 +1,21 @@
 package controllers
 
+import javax.inject.Inject
 import play.api.mvc._
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
 import scala.concurrent.Future
 import com.gu.googleauth._
-import play.api.Play.current
 import org.joda.time.Duration
 
 trait AuthActions extends Actions with Filters {
   val loginTarget: Call = routes.Login.loginAction()
-  val authConfig = Login.googleAuthConfig
+  val authConfig = ExampleConfiguration.googleAuthConfig
   lazy val groupChecker = new GoogleGroupChecker(???) // Can't share these credentials!
 }
 
-object Login extends Controller with AuthActions {
-  val ANTI_FORGERY_KEY = "antiForgeryToken"
+object ExampleConfiguration {
   val googleAuthConfig =
     GoogleAuthConfig(
       "863070799113-9oefm3nnjf0hu4g9k3k1ue3fopfvrtpg.apps.googleusercontent.com",  // The client ID from the dev console
@@ -27,6 +27,14 @@ object Login extends Controller with AuthActions {
                                                    //    so in the last hour (this is stupid unless you are testing :)
       true                                         // Re-authenticate (without prompting) with google when session expires
     )
+
+}
+
+class Login @Inject() (implicit val client: WSClient) extends Controller with AuthActions {
+
+  import ExampleConfiguration.googleAuthConfig
+
+  val ANTI_FORGERY_KEY = "antiForgeryToken"
 
   def login = Action { request =>
     val error = request.flash.get("error")

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,6 +1,6 @@
 name := "play-googleauth-example"
 
-version := "0.3.8-SNAPSHOT"
+version := "0.4.0-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,6 +1,6 @@
 name := "play-googleauth-example"
 
-version := "0.3.5-SNAPSHOT"
+version := "0.3.8-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -2,4 +2,4 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.0")

--- a/module/project/Dependencies.scala
+++ b/module/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
 
   //versions
 
-  val playVersion = "2.4.0"
+  val playVersion = "2.5.0"
 
 
   //libraries

--- a/module/src/main/scala/com/gu/googleauth/filters.scala
+++ b/module/src/main/scala/com/gu/googleauth/filters.scala
@@ -1,6 +1,6 @@
 package com.gu.googleauth
 
-import play.Play
+import akka.stream.Materializer
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Filter, RequestHeader, Result}
 import scala.concurrent.Future
@@ -11,12 +11,12 @@ object GoogleAuthFilters {
   val LOGIN_ORIGIN_KEY = "loginOriginUrl"
   class AuthFilterWithExemptions(
       loginUrl: FilterExemption,
-      exemptions: Seq[FilterExemption]) extends Filter {
+      exemptions: Seq[FilterExemption])(implicit val mat: Materializer) extends Filter {
 
     def apply(nextFilter: (RequestHeader) => Future[Result])
              (requestHeader: RequestHeader): Future[Result] = {
 
-      if (Play.isTest || requestHeader.path.startsWith(loginUrl.path) ||
+      if (requestHeader.path.startsWith(loginUrl.path) ||
         exemptions.exists(exemption => requestHeader.path.startsWith(exemption.path)))
         nextFilter(requestHeader)
       else {

--- a/module/src/main/scala/com/gu/googleauth/filters.scala
+++ b/module/src/main/scala/com/gu/googleauth/filters.scala
@@ -3,6 +3,7 @@ package com.gu.googleauth
 import akka.stream.Materializer
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Filter, RequestHeader, Result}
+import play.Environment
 import scala.concurrent.Future
 
 case class FilterExemption(path: String)
@@ -11,12 +12,12 @@ object GoogleAuthFilters {
   val LOGIN_ORIGIN_KEY = "loginOriginUrl"
   class AuthFilterWithExemptions(
       loginUrl: FilterExemption,
-      exemptions: Seq[FilterExemption])(implicit val mat: Materializer) extends Filter {
+      exemptions: Seq[FilterExemption])(implicit val mat: Materializer, environment: Environment) extends Filter {
 
     def apply(nextFilter: (RequestHeader) => Future[Result])
              (requestHeader: RequestHeader): Future[Result] = {
 
-      if (requestHeader.path.startsWith(loginUrl.path) ||
+      if (environment.isTest || requestHeader.path.startsWith(loginUrl.path) ||
         exemptions.exists(exemption => requestHeader.path.startsWith(exemption.path)))
         nextFilter(requestHeader)
       else {

--- a/module/version.sbt
+++ b/module/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.8-SNAPSHOT"
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
Changes to support Play 2.5:
- ```play.api.mvc.Filter``` requires an ```akka.stream.Materializer```
- Dependency injection