### PR TITLE
Make it much harder to accidentally fail to provide an email domain

### DIFF
--- a/example/app/auth/AuthActions.scala
+++ b/example/app/auth/AuthActions.scala
@@ -20,7 +20,7 @@ trait AuthActions extends Actions with Filters {
     clientId     = conf.getString("your.clientId.config.path").get,
     clientSecret = conf.getString("your.clientSecret.config.path").get,
     redirectUrl  = conf.getString("your.redirectUrl.config.path").get,
-    domain       = conf.getString("your.apps-domain.config.path")
+    domain       = conf.getString("your.apps-domain.config.path").get
   )
   // your app's routing
   override val loginTarget = routes.Login.loginAction()
@@ -34,6 +34,6 @@ trait AuthActions extends Actions with Filters {
       .getOrElse(Set.empty[String])
   // groupChecker only needed here because `Filters` is mixed-in (to provide the `requireGroup` filter example)
   override lazy val groupChecker = new GoogleGroupChecker(
-    new GoogleServiceAccount(???, ???, ???) // from your secret config (and/or via JSON service account credentials file)
+    GoogleServiceAccount(???, ???, ???) // from your secret config (and/or via JSON service account credentials file)
   )
 }

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,6 +1,6 @@
 name := "play-googleauth-example"
 
-version := "0.5.0-SNAPSHOT"
+version := "0.5.2-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/module/src/main/scala/com/gu/googleauth/auth.scala
+++ b/module/src/main/scala/com/gu/googleauth/auth.scala
@@ -25,16 +25,48 @@ import scala.language.postfixOps
  *               Authorization Server prompts the End-User for reauthentication and consent
  * @param antiForgeryKey A string that determines the session key used to store Google's anti forgery token
  */
-case class GoogleAuthConfig(
+case class GoogleAuthConfig private(
   clientId: String,
   clientSecret: String,
   redirectUrl: String,
   domain: Option[String],
-  maxAuthAge: Option[Duration] = None,
-  enforceValidity: Boolean = true,
-  prompt: Option[String] = None,
-  antiForgeryKey: String = "antiForgeryToken"
+  maxAuthAge: Option[Duration],
+  enforceValidity: Boolean,
+  prompt: Option[String],
+  antiForgeryKey: String
 )
+object GoogleAuthConfig {
+  private val defaultMaxAuthAge = None
+  private val defaultEnforceValidity = true
+  private val defaultPrompt = None
+  private val defaultAntiForgeryKey = "antiForgeryToken"
+
+  def apply(
+    clientId: String,
+    clientSecret: String,
+    redirectUrl: String,
+    domain: String,
+    maxAuthAge: Option[Duration] = defaultMaxAuthAge,
+    enforceValidity: Boolean = defaultEnforceValidity,
+    prompt: Option[String] = defaultPrompt,
+    antiForgeryKey: String = defaultAntiForgeryKey
+  ): GoogleAuthConfig = GoogleAuthConfig(clientId, clientSecret, redirectUrl, Some(domain), maxAuthAge, enforceValidity, prompt, antiForgeryKey)
+
+  /**
+    * Creates a GoogleAuthConfig that does not restrict acceptable email domains.
+    * This means any Google account can be used to gain access. If you mean to restrict
+    * access to certain email domains use the `apply` method instead.
+    */
+  def withNoDomainRestriction(
+    clientId: String,
+    clientSecret: String,
+    redirectUrl: String,
+    maxAuthAge: Option[Duration] = defaultMaxAuthAge,
+    enforceValidity: Boolean = defaultEnforceValidity,
+    prompt: Option[String] = defaultPrompt,
+    antiForgeryKey: String = defaultAntiForgeryKey
+  ): GoogleAuthConfig = GoogleAuthConfig(clientId, clientSecret, redirectUrl, None, maxAuthAge, enforceValidity, prompt, antiForgeryKey)
+}
 
 class GoogleAuthException(val message: String, val throwable: Throwable = null) extends Exception(message, throwable)
 


### PR DESCRIPTION
The domain parameter is used to restrict logins to a specific email domain, rather than allowing any google mail account. It's very easy to forget to include this option or to have it be accidentally removed without anyone noticing.

This change removes the GoogleAuthConfig constructor and provides two different methods for creating instances. The default method (`apply`) now explicitly requires a domain. An alternative is provided that does not require a domain and it is named to make it very clear that this will not include domain protection.

While this is a "general-purpose" library in practice the only users are at the Guardian. Our applications all need to enforce a Guardian email check and this makes writing correct code the path of least resistance.

I think `5.3` should be the next version number but since this is a minor breaking change so I'm open to other suggestions.

cc @johnduffell since you've mentioned this before
