### PR TITLE
Specify 0.6.0, not 0.5.3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Versions
 
 For Play 2.5.x use version [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/play-googleauth_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/play-googleauth_2.11):
 ```
-libraryDependencies += "com.gu" %% "play-googleauth" % "0.5.3"
+libraryDependencies += "com.gu" %% "play-googleauth" % "0.6.0"
 ```
 This version has a dependancy on `cats 0.8.*`. Therefore, (for compatibility) it is advised your project or any of its dependendancies do not depend on `cats 0.7.*` or below.
 


### PR DESCRIPTION
I decided that the source incompatibility due to the changes in Cats meant it was worth a bigger version bump.