### PR TITLE
Upgrade cats to 1.0.1 for Play 2.5.x

### DIFF
--- a/module/build.sbt
+++ b/module/build.sbt
@@ -12,7 +12,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 libraryDependencies ++= Seq(
   play % "provided",
   playWS % "provided",
-  "org.typelevel" %% "cats-core" % "0.8.1",
+  "org.typelevel" %% "cats-core" % "1.0.1",
   commonsCodec,
   googleDataAPI,
   "org.scalatest" %% "scalatest" % "2.2.6" % "test"


### PR DESCRIPTION
Just like #48 but for the `play-2.5.x` branch since I'm doing this for [bolt](https://github.com/guardian/bolt) which is on Play 2.5