### PR TITLE
Add publishTo parameter for sbt-sonatype plugin

### DIFF
--- a/module/build.sbt
+++ b/module/build.sbt
@@ -31,6 +31,13 @@ scmInfo := Some(ScmInfo(
   "scm:git:git@github.com:guardian/play-googleauth.git"
 ))
 
+publishTo := Some(
+  if (isSnapshot.value)
+    Opts.resolver.sonatypeSnapshots
+  else
+    Opts.resolver.sonatypeStaging
+)
+
 pomExtra := {
   <url>https://github.com/guardian/play-googleauth</url>
   <developers>


### PR DESCRIPTION
Since #50, `sbt release` doesn't actually work, I *think* because the newer version of `sbt-sonatype` needs a `publishTo` parameter.

Of course, just as with the changes in #50, I can't actually test it without merging this to master, since `sbt-release` wisely doesn't let you release if you have unstaged modified files or if local is out of sync with remote

@adamnfish if you have any suggestions for ways to test things like this before creating the PR, I'm all ears!