### PR TITLE
Rely on Google's token_endpoint for user info, over userinfo_endpoint

### DIFF
--- a/example/app/views/authenticated.scala.html
+++ b/example/app/views/authenticated.scala.html
@@ -14,7 +14,7 @@
         <h1>Authorised</h1>
         <p>This is an authorised page of the example application.</p>
         <p>It uses an AuthAction so will always have a user.</p>
-        <p>In this case the logged in user is <b>@request.user.username</b>.</p>
+        <p>In this case the logged in user is <b>@request.user.username</b> (@request.user.fullName).</p>
         @request.user.avatarUrl.map { avatarUrl =>
             <p><img class="avatar" src="@avatarUrl" alt="@request.user.firstName" /></p>
         }

--- a/module/src/main/scala/com/gu/googleauth/model.scala
+++ b/module/src/main/scala/com/gu/googleauth/model.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
 import org.apache.commons.codec.binary.Base64
 
-case class DiscoveryDocument(authorization_endpoint: String, token_endpoint: String, userinfo_endpoint: String)
+case class DiscoveryDocument(authorization_endpoint: String, token_endpoint: String)
 object DiscoveryDocument {
   val url = "https://accounts.google.com/.well-known/openid-configuration"
   implicit val discoveryDocumentReads = Json.reads[DiscoveryDocument]


### PR DESCRIPTION
This removes a (hopefully superfluous?) server-side call to Google- the data we were getting from the `userinfo_endpoint` was only:

* `picture`
* `given_name`
* `family_name`

These are currently all being returned by the `token_endpoint`, so the subsequent call to `userinfo_endpoint` seems unnecessary... the call to `userinfo_endpoint` has been in this project ever since the [initial commit](https://github.com/guardian/play-googleauth/blob/b2e038b1416/module/src/main/scala/com/gu/googleauth/auth.scala#L41-L51), so I'm not sure if there's a tail of badness that made it necessary...

The [docs for the `token_endpoint`](https://developers.google.com/identity/protocols/OpenIDConnect#exchangecode) do say about `picture`: 

> "Note that this claim is never guaranteed to be present."



...and the ["Obtaining user profile information" section](https://developers.google.com/identity/protocols/OpenIDConnect#obtaininguserprofileinformation) says:

> "To obtain additional profile information about the user ... make an HTTPS GET request to the userinfo endpoint"


...so it may be this is a bad idea.