### PR TITLE
Remove obsolete `com.google.gdata:core` library, and bump Play version

### DIFF
--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,6 +1,6 @@
 name := "play-googleauth-example"
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "play-googleauth" % version.value,

--- a/example/project/build.properties
+++ b/example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.1.6

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -2,4 +2,4 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")

--- a/module/build.sbt
+++ b/module/build.sbt
@@ -5,7 +5,7 @@ name               := "play-googleauth"
 
 organization       := "com.gu"
 
-scalaVersion       := "2.12.4"
+scalaVersion       := "2.12.6"
 
 crossScalaVersions := Seq(scalaVersion.value, "2.11.12")
 
@@ -16,7 +16,6 @@ libraryDependencies ++= Seq(
   playWS % "provided",
   "org.typelevel" %% "cats-core" % "1.0.1",
   commonsCodec,
-  googleDataAPI,
   playTest % "test",
   "org.scalatest" %% "scalatest" % "3.0.3" % "test"
 ) ++ googleDirectoryAPI

--- a/module/project/Dependencies.scala
+++ b/module/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
 
   //versions
 
-  val playVersion = "2.6.13"
+  val playVersion = "2.6.15"
 
 
   //libraries
@@ -21,8 +21,6 @@ object Dependencies {
   val playTest = "com.typesafe.play" %% "play-test" % playVersion
 
   val commonsCodec = "commons-codec" % "commons-codec" % "1.9"
-
-  val googleDataAPI = "com.google.gdata" % "core" % "1.47.1"
 
   /** The google-api-services-admin-directory artifact has a transitive dependency on com.google.guava:guava-jdk5 - a
     * nasty artifact that clashes with the regular com.google.guava:guava artifact, providing two versions of the same

--- a/module/project/build.properties
+++ b/module/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.1.6


### PR DESCRIPTION
Snyk just alerted us on the @guardian/ophan team to an 'Arbitrary Command Execution' vulnerability in `org.mortbay.jetty:jetty`:

https://snyk.io/vuln/SNYK-JAVA-ORGMORTBAYJETTY-32091

...introduced through:

```
com.google.gdata:core@1.47.1 ›
com.google.oauth-client:google-oauth-client-jetty@1.11.0-beta ›
org.mortbay.jetty:jetty@6.1.26
```

The `com.google.gdata:core` library was introduced to `play-googleauth` with #20 in December 2014, but it became superfluous in April 2015 with #23. We can just remove it!

Note that the vulnerability probably wouldn't have actually affected us, because we weren't actually *running* Jetty, but in any case this is getting rid of noise.

Updating to Play 2.6.15 also gets us the less vulnerable version of `jackson-databind`:

* https://github.com/playframework/playframework/pull/8352
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7489