### PR TITLE
Handle secret rotation for signature-verification of the anti-forgery token

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 libraryDependencies ++= Seq(
   play % "provided",
   playWS % "provided",
+  "com.gu.play-secret-rotation" %% "core" % "0.10",
   "org.typelevel" %% "cats-core" % "1.0.1",
   commonsCodec,
   playTest % "test",


### PR DESCRIPTION
The anti-forgery token used by `play-googleauth` has been signed using the [Play Application Secret](https://www.playframework.com/documentation/2.6.x/ApplicationSecret) since https://github.com/guardian/play-googleauth/pull/52 was released with v0.7.2.

This worked well, until we started rotating the Play Application Secret using the new [`play-secret-rotation`](https://github.com/guardian/play-secret-rotation) library (added to Ophan with https://github.com/guardian/ophan/pull/2712). Although the `play-secret-rotation` library fixes Play to sign & verify the **Session Cookie** correctly, unfortunately the `play-googleauth` library was not updated to correctly sign & verify the **Anti-Forgery Token** - specifically, it would only ever use the secret _that was active when the box started up_. This more or less works, so long as boxes are all deployed at the same time, but if only _some_ of the boxes refresh at some time - after a rotation of the secret - then some boxes will be verifying the token with *only* the old secret, and others with only the new secret, resulting in a lot of errors.

[We saw this in Ophan](https://docs.google.com/document/d/1GepbgGzjJQKDtHzaCFS7j_hVfjIBly7wpa7-uZchwpY/edit?usp=sharing), when Dashboard was served by 2 boxes (`i-0def67fff39cf9909`, started on 2018-08-03 14:08, and `i-0a22d14b1b6aa5d7f`, started on 2018-08-02 16:06) which had two different
secrets, because they were were started on two different days, and we rotate our key every 6 hours. The boxes were serving the Ophan Dashboard all through the weekend, and we saw [a lot of user reports of the problem](https://groups.google.com/a/guardian.co.uk/d/msg/ophan/og5eUiW_0Qo/PhPzRcMfBwAJ) surfacing from Friday 3rd, to the morning of Monday 6th, when an automated deploy of Dashboard cleared the problem at 10:09am.

This change updates `play-googleauth`, adding a dependency on `com.gu.play-secret-rotation:core` which allows it to understand not only what the current active secret is - but also what the other acceptable secrets for verification are. Adding this extra dependency may be a bit controversial - and it will mean that users who update to the latest version of `play-googleauth` are nudged towards rotating their secrets with `play-secret-rotation` - but overall I think it's the right thing to do for us.

