### PR TITLE
Fix sbt release process by disabling `scripted` plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ cache:
   directories:
   - $HOME/.sbt
   - $HOME/.ivy2
-script: sbt ++$TRAVIS_SCALA_VERSION test && sbt ++$TRAVIS_SCALA_VERSION scripted; result=$? ; find $HOME/.sbt -name "*.lock" -type f -delete ; find $HOME/.ivy2/cache -name "*[\[\]\(\)]*.properties" -type f -delete ; (exit $result)
+script: sbt ++$TRAVIS_SCALA_VERSION test; result=$? ; find $HOME/.sbt -name "*.lock" -type f -delete ; find $HOME/.ivy2/cache -name "*[\[\]\(\)]*.properties" -type f -delete ; (exit $result)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,3 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-
-libraryDependencies += { "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value }


### PR DESCRIPTION
I introduced the `scripted` plugin with https://github.com/guardian/play-googleauth/pull/64, but unfortunately it breaks the artifact publishing process, due to it failing as an unresolved dependency on publishing cross-compiled scala versions:

```
::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.scala-sbt#scripted-sbt_2.11;1.1.6: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]
[warn]  Note: Unresolved dependencies path:
[warn]      org.scala-sbt:scripted-sbt_2.11:1.1.6 ((sbt.ScriptedPlugin.projectSettings) ScriptedPlugin.scala#L43)
[warn]        +- com.gu:play-googleauth_2.11:0.7.7-SNAPSHOT
```

I'm disabling this for now, and I'm hoping to get someone on StackOverflow to explain to me how to fix it! https://stackoverflow.com/q/51984454/438886