### PR TITLE
Turn on HSTS if we expect the user to be using HTTPS

### DIFF
--- a/src/main/scala/com/gu/googleauth/auth.scala
+++ b/src/main/scala/com/gu/googleauth/auth.scala
@@ -1,6 +1,7 @@
 package com.gu.googleauth
 
 import java.math.BigInteger
+import java.net.URI
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.SecureRandom
 import java.time.Clock
@@ -43,7 +44,9 @@ case class GoogleAuthConfig private(
   enforceValidity: Boolean,
   prompt: Option[String],
   antiForgeryChecker: AntiForgeryChecker
-)
+) {
+  val impliesEndUserHasHTTPSConnection: Boolean = new URI(redirectUrl).getScheme == "https"
+}
 object GoogleAuthConfig {
   private val defaultMaxAuthAge = None
   private val defaultEnforceValidity = true


### PR DESCRIPTION
[HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) stands for 'HTTP Strict Transport Security', and it's a way for sites to make sure that browsers *only* connect to them over https - so if a user enters simply `status.ophan.co.uk` the BROWSER will correct that to https://status.ophan.co.uk/ - rather than attempting to connect to http://status.ophan.co.uk/ (which just hangs indefinitely, our ELB's don't listen on HTTP port 80).

When returning HSTS headers the only risk is that you'll make browsers be strict-HTTPS-only for domains that you might later want to access over insecure HTTP - but that's become very rare. In Production, for webapps where users are actually *authenticated* (as with `play-googleauth`), it would be terrible security practice to even consider not using HTTPS between the end-user and our trusted networks. In Dev, for localhost, we're usually less strict, and have insecure HTTP, eg http://localhost:9000

This change will add HSTS response headers to all endpoints placed behind an `AuthAction` where the `GoogleAuthConfig` is configured to redirect to an *HTTPS* url for the OAuth callback. So when `redirectUrl` is:

* https://dashboard.ophan.co.uk/oauth2callback <- HSTS returned
* http://localhost:9000/oauth2callback <- no HSTS header returned

#### Fixing unwanted HSTS

If browsers ends up with HSTS you don't want, getting rid of it is not easy, and has to be done either by the service changing it's domain name to a *new* name not blocked by HSTS (LARGE hassle!), or manually by the end-user updating developer-settings in their web browser (only feasible for where the number of affected users is very small, ie for 2 or 3 developers).

* Chrome: https://stackoverflow.com/q/38968510/438886
  chrome://net-internals/#hsts

Also: https://www.thesslstore.com/blog/clear-hsts-settings-chrome-firefox/

#### What about Play's `RedirectHttpsComponents` trait?

In August 2018 @sihil tried out Playframework's `RedirectHttpsComponents` trait (which both redirects HTTP->HTTPS, and adds HSTS response headers) with Janus.

Unfortunately that trait turned out to behave badly for our Production environments, because we *don't* have HTTPS between the AWS ELB and our EC2 Play appservers (who does?!), and yet the trait was redirecting the ELB's healthcheck requests to HTTPS:

* https://github.com/guardian/janus/pull/1428
* https://github.com/guardian/janus/pull/1414
* https://github.com/guardian/janus/pull/1391
