### PR TITLE
Update to latest version of `play-secret-rotation`, drop Scala v2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,16 +5,16 @@ name               := "play-googleauth"
 
 organization       := "com.gu"
 
-scalaVersion       := "2.12.6"
+scalaVersion       := "2.12.8"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.11.12")
+crossScalaVersions := Seq(scalaVersion.value)
 
 resolvers += Resolver.typesafeIvyRepo("releases")
 
 libraryDependencies ++= Seq(
   play % "provided",
   playWS % "provided",
-  "com.gu.play-secret-rotation" %% "core" % "0.12",
+  "com.gu.play-secret-rotation" %% "core" % "0.15",
   "org.typelevel" %% "cats-core" % "1.0.1",
   commonsCodec,
   playTest % "test",

--- a/src/main/scala/com/gu/googleauth/auth.scala
+++ b/src/main/scala/com/gu/googleauth/auth.scala
@@ -12,7 +12,7 @@ import com.gu.play.secretrotation.SnapshotProvider
 import io.jsonwebtoken.SignatureAlgorithm.HS256
 import io.jsonwebtoken._
 import org.joda.time.Duration
-import play.api.http.{HttpConfiguration, SecretConfiguration}
+import play.api.http.HttpConfiguration
 import play.api.libs.json.JsValue
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.Redirect
@@ -102,8 +102,8 @@ case class AntiForgeryChecker(
   sessionIdKeyName: String = "play-googleauth-session-id"
 ) {
 
-  private def base64EncodedSecretFrom(sc: SecretConfiguration): String =
-    Base64.getEncoder.encodeToString(sc.secret.getBytes(UTF_8))
+  private def base64EncodedSecretFrom(secret: String): String =
+    Base64.getEncoder.encodeToString(secret.getBytes(UTF_8))
 
   def ensureUserHasSessionId(t: String => Future[Result])(implicit request: RequestHeader, ec: ExecutionContext):Future[Result] = {
     val sessionId = request.session.get(sessionIdKeyName).getOrElse(generateSessionId())
@@ -150,7 +150,7 @@ object AntiForgeryChecker {
   @deprecated("You can use this method if you never rotate your Play Application secret, but that's not a good security practice.\n" +
     "Use https://github.com/guardian/play-secret-rotation and the vanilla `AntiForgeryChecker` constructor","0.7.7")
   def borrowSettingsFromPlay(httpConfiguration: HttpConfiguration): AntiForgeryChecker =
-    AntiForgeryChecker(InitialSecret(httpConfiguration.secret), signatureAlgorithmFromPlay(httpConfiguration))
+    AntiForgeryChecker(InitialSecret(httpConfiguration.secret.secret), signatureAlgorithmFromPlay(httpConfiguration))
 
   /**
     * If you're happy using the Playframework, you're probably happy to use their choice of JWT

--- a/src/test/scala/com/gu/googleauth/AntiForgeryCheckerTest.scala
+++ b/src/test/scala/com/gu/googleauth/AntiForgeryCheckerTest.scala
@@ -17,7 +17,7 @@ class AntiForgeryCheckerTest extends FlatSpec with Matchers with TryValues {
 
   val ExampleSessionId = AntiForgeryChecker.generateSessionId()
 
-  val antiForgery = AntiForgeryChecker(InitialSecret(SecretConfiguration("reallySecret")), HS256)
+  val antiForgery = AntiForgeryChecker(InitialSecret("reallySecret"), HS256)
 
   "Anti Forgery" should "fail if token is signed with other algorithm, even if it has the same secret" in {
     val badAlgorithmAntiForgery = antiForgery.copy(signatureAlgorithm = HS384)
@@ -65,7 +65,7 @@ class AntiForgeryCheckerTest extends FlatSpec with Matchers with TryValues {
   it should "accept a token signed with any of the accepted secrets" in {
     val overlapInterval = Interval.of(Instant.now().minusSeconds(50), ofSeconds(100))
     val checkerAcceptingMultipleSecrets = AntiForgeryChecker(
-      TransitioningSecret(SecretConfiguration("alpha"),SecretConfiguration("beta"),
+      TransitioningSecret("alpha","beta",
         overlapInterval), HS256)
 
     val tokenSignedWithOlderSecret =


### PR DESCRIPTION
`play-secret-rotation` v0.15 supports both Play 2.6 & 2.7 thanks to https://github.com/guardian/play-secret-rotation/pull/8

In order to use `play-secret-rotation` v0.15 in a project that also uses `play-googleauth`, `play-googleauth` needs to be built against that version of `play-secret-rotation` too (due to binary-incompatible case class changes).