### PR TITLE
Add Scala 2.13 support everywhere we can (ie Play 2.7, but not Play 2.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-   - 2.12.6
+   - 2.12.10
 
 jdk:
   - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,8 @@ val sonatypeReleaseSettings = Seq(
     "scm:git:git@github.com:guardian/play-googleauth.git"
   )),
 
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-
-  releaseProcess := Seq(
+  releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
+  releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,
     runClean,
@@ -40,8 +39,8 @@ val sonatypeReleaseSettings = Seq(
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    // For cross-build projects, use releaseStepCommand("+publishSigned")
-    releaseStepCommandAndRemaining("publishSigned"),
+    // For non cross-build projects, use releaseStepCommand("publishSigned")
+    releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
     setNextVersion,
     commitNextVersion,
@@ -51,22 +50,22 @@ val sonatypeReleaseSettings = Seq(
 
 def projectWithPlayVersion(majorMinorVersion: String) =
   Project(s"play-v$majorMinorVersion", file(s"play-v$majorMinorVersion")).settings(
-    scalaVersion       := "2.12.9",
+    scalaVersion       := "2.12.10",
 
     scalacOptions ++= Seq("-feature", "-deprecation"),
 
     libraryDependencies ++= Seq(
-      "com.gu.play-secret-rotation" %% "core" % "0.15",
-      "org.typelevel" %% "cats-core" % "1.0.1",
+      "com.gu.play-secret-rotation" %% "core" % "0.17",
+      "org.typelevel" %% "cats-core" % "2.0.0",
       commonsCodec,
-      "org.scalatest" %% "scalatest" % "3.0.3" % "test"
+      "org.scalatest" %% "scalatest" % "3.0.8" % "test"
     ) ++ googleDirectoryAPI ++ playLibs(majorMinorVersion),
 
     sonatypeReleaseSettings
   )
 
 lazy val `play-v26` = projectWithPlayVersion("26")
-lazy val `play-v27` = projectWithPlayVersion("27")
+lazy val `play-v27` = projectWithPlayVersion("27").settings(crossScalaVersions := Seq(scalaVersion.value, "2.13.1"))
 
 lazy val `play-googleauth-root` = (project in file(".")).aggregate(
   `play-v26`,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.7")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")


### PR DESCRIPTION
This project compiles with Scala 2.12 by default, but now additionally can cross-compile to Scala 2.13 for the versions of Play that support it (ie Play 2.7, but not Play 2.6).

* `cats-core` & `scalatest` both updated to cross-compiled versions
* `play-secret-rotation` updated to cross-compiled version https://github.com/guardian/play-secret-rotation/pull/9