### PR TITLE
Update google-oauth-client to v1.31.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
     Seq(play, playWS, playTest, playAhcWs, mockWs)
   }
 
-  val commonsCodec = "commons-codec" % "commons-codec" % "1.9"
+  val commonsCodec = "commons-codec" % "commons-codec" % "1.14"
 
   /** The google-api-services-admin-directory artifact has a transitive dependency on com.google.guava:guava-jdk5 - a
     * nasty artifact that clashes with the regular com.google.guava:guava artifact, providing two versions of the same

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,7 +44,8 @@ object Dependencies {
     * @see https://github.com/guardian/subscriptions-frontend/pull/363#issuecomment-186190081
     */
   val googleDirectoryAPI = Seq(
-    "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev53-1.20.0" exclude("com.google.guava", "guava-jdk5"),
+    "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev118-1.25.0" exclude("com.google.guava", "guava-jdk5"),
+    "com.google.api-client" % "google-api-client" % "1.30.9", // Required as it fixes https://github.com/googleapis/google-api-java-client/issues/1487
     "com.google.guava" % "guava" % "25.0-jre"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,7 @@ object Dependencies {
     */
   val googleDirectoryAPI = Seq(
     "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev118-1.25.0" exclude("com.google.guava", "guava-jdk5"),
-    "com.google.api-client" % "google-api-client" % "1.30.9", // Required as it fixes https://github.com/googleapis/google-api-java-client/issues/1487
+    "com.google.api-client" % "google-api-client" % "1.30.10", // Required as it fixes https://github.com/googleapis/google-api-java-client/issues/1487
     "com.google.guava" % "guava" % "25.0-jre"
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,3 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This change is a dependency update. It updates the following three modules:

- `google-api-services-admin-directory`
- `google-api-client` 
- `commons-codec` 

## Why is this change needed?
Module`google-oauth-client` versions up to 1.30.x are affected by a high-severity security vulnerability (see [Snyk report](https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-575276)).

The current change updates module `google-api-services-admin-directory` that has a transitive dependency through `google-api-client` on one of these vulnerable versions.

A higher version of `google-api-client` than the one picked up by `google-api-services-admin-directory` is specified explicitly as it fixes the issue https://github.com/googleapis/google-api-java-client/issues/1487.

The `commons-codec` module is additionally updated to resolve another low-severity vulnerability in the same repo (see [Snyk report](https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518) and comments below).

## Checks

- Tests from running `sbt test` pass