### PR TITLE
Update readme with latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,28 @@ Versions
 --------
 
 ### Supported Play Versions
-
-* Play **2.7** : use [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v27_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v27_2.12)
+#### Scala 2.13
+* Play **2.8** : use [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v28_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v28_2.13)
   ```
   libraryDependencies += "com.gu.play-googleauth" %% "play-v27" % "[maven version number]"
   ```
+* Play **2.7** : use [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v27_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v27_2.13)
+  ```
+  libraryDependencies += "com.gu.play-googleauth" %% "play-v27" % "[maven version number]"
+  ```
+  
+#### Scala 2.12
+
+* Play **2.8** : use [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v28_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v28_2.12)
+  ```
+  libraryDependencies += "com.gu.play-googleauth" %% "play-v27" % "[maven version number]"
+  ```
+* Play **2.7** : use [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v27_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v27_2.12)
+  ```
+  libraryDependencies += "com.gu.play-googleauth" %% "play-v27" % "[maven version number]"
+  ```   
+
+We no longer support the below version for Play 2.6, but it can be found here if it is needed:
 * Play **2.6** : use [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v26_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu.play-googleauth/play-v26_2.12)
   ```
   libraryDependencies += "com.gu.play-googleauth" %% "play-v26" % "[maven version number]"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.8-SNAPSHOT"
+version in ThisBuild := "2.0.0"


### PR DESCRIPTION
Since PR #79 was merged and [published](https://search.maven.org/artifact/com.gu.play-googleauth/play-v28_2.13/2.0.0/jar), we should link to the latest versions of this library on Maven. 