### PR TITLE
Remove use of deprecated `GoogleCredential` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,24 +123,18 @@ Once you have completed those 3 steps, you should be able to integrate it in you
   - This is how you can build your credentials from the json cert file you have downloaded:
 
 ```scala
-import java.io.FileInputStream
-
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
-import com.gu.googleauth.GoogleServiceAccount
+import org.apache.commons.io.Charsets.UTF_8
+import org.apache.commons.io.IOUtils
+import com.google.auth.oauth2.ServiceAccountCredentials
 
 object GoogleAuthConf {
-  val impersonatedUser = ??? // read from config
-}
-
-private lazy val credentials: GoogleCredential = {
-  val fileInputStream = new FileInputStream("/path/to/your-service-account-cert.json")
-  GoogleCredential.fromStream(fileInputStream)
+  val impersonatedUser: String = ??? // read from config
+  val serviceAccountCert: String = ??? // JSON certificate from Google Developers Console - read from secure storage
 }
 
 private val serviceAccount = GoogleServiceAccount(
-  credentials.getServiceAccountId, // This should contain the *email address* that is associated with your service account
-  credentials.getServiceAccountPrivateKey, // This should contain the *private key* that is associated with your service account
-  GoogleAuthConf.impersonatedUser // This is the admin user email address we mentioned earlier
+  GoogleAuthConf.impersonatedUser, // This is the admin user email address we mentioned earlier
+  ServiceAccountCredentials.fromStream(IOUtils.toInputStream(serviceAccountCert, UTF_8))
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,8 +50,8 @@ val sonatypeReleaseSettings = Seq(
 
 def projectWithPlayVersion(majorMinorVersion: String) =
   Project(s"play-v$majorMinorVersion", file(s"play-v$majorMinorVersion")).settings(
-    scalaVersion       := "2.12.10",
-
+    scalaVersion       := "2.12.12",
+    crossScalaVersions := Seq(scalaVersion.value, "2.13.4"),
     scalacOptions ++= Seq("-feature", "-deprecation"),
 
     libraryDependencies ++= Seq(
@@ -65,8 +65,8 @@ def projectWithPlayVersion(majorMinorVersion: String) =
     sonatypeReleaseSettings
   )
 
-lazy val `play-v27` = projectWithPlayVersion("27").settings(crossScalaVersions := Seq(scalaVersion.value, "2.13.1"))
-lazy val `play-v28` = projectWithPlayVersion("28").settings(crossScalaVersions := Seq(scalaVersion.value, "2.13.1"))
+lazy val `play-v27` = projectWithPlayVersion("27")
+lazy val `play-v28` = projectWithPlayVersion("28")
 
 lazy val `play-googleauth-root` = (project in file(".")).aggregate(
   `play-v27`,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,6 +46,7 @@ object Dependencies {
   val googleDirectoryAPI = Seq(
     "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20191003-1.30.8" exclude("com.google.guava", "guava-jdk5"),
     "com.google.api-client" % "google-api-client" % "1.31.1", // https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-575276
+    "com.google.auth" % "google-auth-library-oauth2-http" % "0.22.0",
     "com.google.guava" % "guava" % "30.0-jre"
   )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.3-SNAPSHOT"
+version in ThisBuild := "2.1.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

This change is only related to the Google-Group-checking code in `play-googleauth`, which was using a deprecated class:

The `com.google.api.client.googleapis.auth.oauth2.GoogleCredential` class in https://github.com/googleapis/google-api-java-client was deprecated in May 2019 by https://github.com/googleapis/google-api-java-client/pull/1258 ...the deprecation advice recommends using the classes from the new library: https://github.com/googleapis/google-auth-library-java

This commit switches to using the new `com.google.auth.oauth2.ServiceAccountCredentials` class from the
`google-auth-library-oauth2-http` artifact. Given this new class, our custom `com.gu.googleauth.GoogleServiceAccount` Scala case class is no longer necessary and I've removed it, in favour of the user passing us an instance of `ServiceAccountCredentials` - which is actually easier for a user to generate! Here's an example of how you make and use
an instance of the new credentials:

```scala
import org.apache.commons.io.Charsets.UTF_8
import org.apache.commons.io.IOUtils
import com.google.auth.oauth2.ServiceAccountCredentials
import com.gu.googleauth.GoogleGroupChecker

val impersonatedUser: String = ... // email address of the 'impersonated' account
val serviceAccountCert: String = ... // from Google Developers Console
val credentials  =
  ServiceAccountCredentials.fromStream(IOUtils.toInputStream(serviceAccountCert, UTF_8))

val groupChecker = new GoogleGroupChecker(impersonatedUser, credentials)
```

In Ophan, our old code to produce the custom `com.gu.googleauth.GoogleServiceAccount` instance actually invoked the now deprecated `com.google.api.client.googleapis.auth.oauth2.GoogleCredential` class - we'd been stuck on an old version of `play-googleauth` for some time because we have deprecation warnings set as fatal in our sbt build, and updating to later versions of `play-googleauth` would have meant accepting the updated `google-api-client` dependency where the class was fatally deprecated.

## How to test
Using the https://github.com/guardian/ophan/pull/3974, I've checked that I can still login using the new code in `play-googleauth`.
