### PR TITLE
Don't pass on akka-http as an explicit-runtime dependency, avoid ClassNotFoundExceptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,9 +57,9 @@ def projectWithPlayVersion(majorMinorVersion: String) =
     libraryDependencies ++= Seq(
       "com.gu.play-secret-rotation" %% "core" % "0.17",
       "org.typelevel" %% "cats-core" % "2.0.0",
-      "com.typesafe.akka" %% "akka-http-core" % "10.2.0",
       commonsCodec,
-      "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+      "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+      "com.typesafe.akka" %% "akka-http-core" % "10.1.12" % Test
     ) ++ googleDirectoryAPI ++ playLibs(majorMinorVersion),
 
     sonatypeReleaseSettings


### PR DESCRIPTION
The Play framework is [_really particular_](https://www.playframework.com/documentation/2.8.x/ScalaAkka#Updating-Akka-version) about the versions of Akka and Akka HTTP that it uses - unless you're directly using Akka HTTP, it's best to avoid explicitly adding Akka HTTP as a dependency (even a transitive one) on a Play project, because it's quite likely you'll choose a different version to Play, and [mixed versions aren't allowed](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed).

In the case of PR https://github.com/guardian/play-googleauth/pull/79, which added `akka-http` as a runtime dependency of `play-googleauth`, the dependency caused `ClassNotFoundException`s at runtime in Ophan when we upgraded to the latest version of `play-googleauth`:

```
[error] Caused by: java.lang.ClassNotFoundException: akka.http.javadsl.UseHttp2
[error] 	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
[error] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
[error] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
[error] 	at play.core.server.AkkaHttpServerProvider.createServer(AkkaHttpServer.scala:647)
[error] 	at play.core.server.AkkaHttpServerProvider.createServer(AkkaHttpServer.scala:645)
[error] 	at play.core.server.DevServerStart$.$anonfun$mainDev$1(DevServerStart.scala:268)
```

Note that PR #79 mentions that [the `akka-http` dependency is only needed to make the **tests** compile](https://github.com/guardian/play-googleauth/pull/79/commits/25a86c666736a581c0f58e5bdada546005a91411) - this gives us an easy fix: only add `akka-http` as a dependency for the **tests**, _not_ the main code - ie make it a [test-scoped dependency](https://www.scala-sbt.org/1.x/docs/Library-Dependencies.html#Per-configuration+dependencies), by adding `% Test` on the end:

https://github.com/guardian/play-googleauth/blob/04cefaa796fdc484f056d3c277da0fb0b02e3e02/build.sbt#L62

Now projects _using_ `play-googleauth` won't have any version of `akka-http` transitively & problematically included for them - and the tests will still compile!

I've also lowered the version of `akka-http` used within the tests to make it a little more realistic, to a version that's apparently what real versions ([2.7.7](https://github.com/playframework/playframework/blob/2.7.7/project/Dependencies.scala#L11), [2.8.5](https://github.com/playframework/playframework/blob/2.8.5/project/Dependencies.scala#L11)) of Play actually are using  - but that's just a nod to realism in the tests, it doesn't have to be completely accurate there!

