### PR TITLE
Fix SNYK-JAVA-COMGOOGLEOAUTHCLIENT-575276, update google-api-client

### DIFF
--- a/play-v27/src/main/scala/com/gu/googleauth/groups.scala
+++ b/play-v27/src/main/scala/com/gu/googleauth/groups.scala
@@ -5,7 +5,7 @@ import java.security.PrivateKey
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.services.admin.directory.{Directory, DirectoryScopes}
+import com.google.api.services.directory.{Directory, DirectoryScopes}
 
 import scala.collection.JavaConverters._
 import scala.concurrent._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,9 +44,9 @@ object Dependencies {
     * @see https://github.com/guardian/subscriptions-frontend/pull/363#issuecomment-186190081
     */
   val googleDirectoryAPI = Seq(
-    "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev118-1.25.0" exclude("com.google.guava", "guava-jdk5"),
-    "com.google.api-client" % "google-api-client" % "1.30.10", // Required as it fixes https://github.com/googleapis/google-api-java-client/issues/1487
-    "com.google.guava" % "guava" % "25.0-jre"
+    "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20191003-1.30.8" exclude("com.google.guava", "guava-jdk5"),
+    "com.google.api-client" % "google-api-client" % "1.31.1", // https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-575276
+    "com.google.guava" % "guava" % "30.0-jre"
   )
 
 }


### PR DESCRIPTION
Snyk rates this as a high-severity issue: https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-575276

> Remediation
> Upgrade com.google.oauth-client:google-oauth-client to version **1.31.0** or higher.

Note that, slightly confusingly, we had a [prior PR](https://github.com/guardian/play-googleauth/pull/77) in `play-googleauth` titled "Update google-oauth-client to v1.31.0", but the title was at odds with the actual change in that PR (easy to do!), which only updated the library to v1.30.10:

https://github.com/guardian/play-googleauth/blob/f8422fed4f244f13a653d1f98ecbf2cd538d2ebc/project/Dependencies.scala#L48

As far as SNYK-JAVA-COMGOOGLEOAUTHCLIENT-575276 goes, the commit for that was https://github.com/googleapis/google-oauth-java-client/commit/13433cd7, which indeed was only initially released with v1.31.0.

I've also updated a couple of other dependencies to their latest versions.
