### PR TITLE
Bump various dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,16 +30,16 @@ val sonatypeReleaseSettings = Seq(
 
 def projectWithPlayVersion(majorMinorVersion: String) =
   Project(s"play-v$majorMinorVersion", file(s"play-v$majorMinorVersion")).settings(
-    scalaVersion       := "2.12.16",
-    crossScalaVersions := Seq(scalaVersion.value, "2.13.8"),
+    scalaVersion       := "2.12.17",
+    crossScalaVersions := Seq(scalaVersion.value, "2.13.10"),
     scalacOptions ++= Seq("-feature", "-deprecation"),
 
     libraryDependencies ++= Seq(
-      "com.gu.play-secret-rotation" %% "core" % "0.35",
-      "org.typelevel" %% "cats-core" % "2.8.0",
+      "com.gu.play-secret-rotation" %% "core" % "0.37",
+      "org.typelevel" %% "cats-core" % "2.9.0",
       commonsCodec,
-      "org.scalatest" %% "scalatest" % "3.2.12" % Test,
-      "com.typesafe.akka" %% "akka-http-core" % "10.2.9" % Test
+      "org.scalatest" %% "scalatest" % "3.2.15" % Test,
+      "com.typesafe.akka" %% "akka-http-core" % "10.2.10" % Test
     ) ++ googleDirectoryAPI ++ playLibs(majorMinorVersion),
 
     sonatypeReleaseSettings

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,9 +44,9 @@ object Dependencies {
     * @see https://github.com/guardian/subscriptions-frontend/pull/363#issuecomment-186190081
     */
   val googleDirectoryAPI = Seq(
-    "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20220621-1.32.1",
+    "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20230103-2.0.0",
     "com.google.api-client" % "google-api-client" % "2.1.2", // https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-2807808
-    "com.google.auth" % "google-auth-library-oauth2-http" % "1.8.1"
+    "com.google.auth" % "google-auth-library-oauth2-http" % "1.14.0"
   ).map(_ exclude("com.google.guava", "guava-jdk5")) :+ "com.google.guava" % "guava" % "31.1-jre"
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,7 @@ object Dependencies {
     */
   val googleDirectoryAPI = Seq(
     "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20220621-1.32.1",
-    "com.google.api-client" % "google-api-client" % "1.35.2", // https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-2807808
+    "com.google.api-client" % "google-api-client" % "2.1.2", // https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-2807808
     "com.google.auth" % "google-auth-library-oauth2-http" % "1.8.1"
   ).map(_ exclude("com.google.guava", "guava-jdk5")) :+ "com.google.guava" % "guava" % "31.1-jre"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15")


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR aims to batch up the various Scala Steward dependency updates in the project: 
<img width="733" alt="image" src="https://user-images.githubusercontent.com/4633246/212869710-edd894bd-ab91-4b44-b086-4f63f5ea7030.png">

Some these versions were causing an issue in Ophan: 
```
Caused by: java.lang.IllegalStateException: You are currently running with version 2.1.2 of google-api-client. You need at least version 1.31.1 of google-api-client to run version 1.32.1 of the Admin SDK API library.
```

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Can we do a beta release of this change to confirm it works in other repos i.e. Ophan? 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The project is using the latest dependency versions. 
