### PR TITLE
wrong repo url in sonatype.sbt?

### DIFF
--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -8,7 +8,7 @@ ThisBuild / scmInfo := Some(ScmInfo(
 ))
 
 ThisBuild / pomExtra := (
-  <url>https://github.com/guardian/play-secret-rotation</url>
+  <url>https://github.com/guardian/play-googleauth</url>
     <developers>
       <developer>
         <id>rtyley</id>


### PR DESCRIPTION
## What does this change?
I noticed that following the link from maven you end up in the wrong repo, not sure if it was intentional but it would make sense to me that this would point to here ?
In case it's wrong I'm not sure if it's worth having a release for that but maybe have it fixed for the next one.

## How to test
I guess the url for this repo would show when searching this library in the places like the maven repo?

