### PR TITLE
Support requiring 2FA for authentication, check `isEnrolledIn2Sv`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ def projectWithPlayVersion(playVersion: PlayVersion) =
       "org.typelevel" %% "cats-core" % "2.9.0",
       commonsCodec,
       "org.scalatest" %% "scalatest" % "3.2.16" % Test,
+      "software.amazon.awssdk" % "ssm" % "2.21.7" % Test
     ) ++ googleDirectoryAPI ++ playVersion.playLibs,
 
     sonatypeReleaseSettings

--- a/play-v27/src/main/scala/com/gu/googleauth/TwoFactorAuthChecker.scala
+++ b/play-v27/src/main/scala/com/gu/googleauth/TwoFactorAuthChecker.scala
@@ -1,0 +1,22 @@
+package com.gu.googleauth
+
+import com.google.api.services.directory.DirectoryScopes.ADMIN_DIRECTORY_USER_READONLY
+import com.google.auth.oauth2.GoogleCredentials
+import com.gu.googleauth.internal.DirectoryService
+
+import scala.concurrent.{ExecutionContext, Future, blocking}
+
+/**
+ * Uses the `isEnrolledIn2Sv` field on https://developers.google.com/admin-sdk/directory/reference/rest/v1/users
+ * to check the 2FA status of a user.
+ *
+ * @param googleCredentials must have read-only access to retrieve a User using the Admin SDK Directory API
+ */
+class TwoFactorAuthChecker(googleCredentials: GoogleCredentials) {
+
+  private val usersApi = DirectoryService(googleCredentials, ADMIN_DIRECTORY_USER_READONLY).users()
+  
+  def check(userEmail: String)(implicit ec: ExecutionContext): Future[Boolean] = Future { blocking {
+    usersApi.get(userEmail).execute().getIsEnrolledIn2Sv
+  }}
+}

--- a/play-v27/src/main/scala/com/gu/googleauth/auth.scala
+++ b/play-v27/src/main/scala/com/gu/googleauth/auth.scala
@@ -34,6 +34,7 @@ import play.api.libs.ws.WSBodyWritables._
  * @param prompt An optional space delimited, case sensitive list of ASCII string values that specifies whether the
  *               Authorization Server prompts the End-User for reauthentication and consent
  * @param antiForgeryChecker configuration for the checks that ensure the OAuth callback can't be forged
+ * @param twoFactorAuthChecker only allow users to authenticate if they have 2FA enabled
   */
 case class GoogleAuthConfig(
   clientId: String,
@@ -43,7 +44,8 @@ case class GoogleAuthConfig(
   maxAuthAge: Option[Duration] = GoogleAuthConfig.defaultMaxAuthAge,
   enforceValidity: Boolean = GoogleAuthConfig.defaultEnforceValidity,
   prompt: Option[String] = GoogleAuthConfig.defaultPrompt,
-  antiForgeryChecker: AntiForgeryChecker
+  antiForgeryChecker: AntiForgeryChecker,
+  twoFactorAuthChecker: Option[TwoFactorAuthChecker] = None
 )
 
 object GoogleAuthConfig {

--- a/play-v27/src/main/scala/com/gu/googleauth/groups.scala
+++ b/play-v27/src/main/scala/com/gu/googleauth/groups.scala
@@ -13,7 +13,9 @@ import scala.jdk.CollectionConverters._
  *
  * You can use a Service Account to access the Directory API (in fact, non-Service access, ie web-user,
  * doesn't seem to work?). The Service Account needs the following scope:
- * https://www.googleapis.com/auth/admin.directory.group.readonly
+ * https://www.googleapis.com/auth/admin.directory.group.readonly - note that if you're using
+ * [[TwoFactorAuthChecker]] it requires a different scope:
+ * https://www.googleapis.com/auth/admin.directory.user.readonly
  *
  * So long as you have the Service Account certificate as a string, you can easily make
  * an instance of com.google.auth.oauth2.ServiceAccountCredentials with

--- a/play-v27/src/test/scala/com/gu/googleauth/TwoFactorAuthCheckerCLITester.scala
+++ b/play-v27/src/test/scala/com/gu/googleauth/TwoFactorAuthCheckerCLITester.scala
@@ -1,0 +1,51 @@
+package com.gu.googleauth
+
+import com.google.auth.oauth2.GoogleCredentials
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProvider, ProfileCredentialsProvider}
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.regions.Region.EU_WEST_1
+import software.amazon.awssdk.services.ssm.SsmClient
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+/**
+ * This is a non-production piece of code, only intended for checking that Google Credentials are correctly set up,
+ * and that we're able to get a good response from the Google Admin SDK Directory API.
+ */
+object TwoFactorAuthCheckerCLITester extends App {
+
+  val checker = new TwoFactorAuthChecker(GoogleCredentialsInDev.loadGuardianGoogleCredentials())
+
+  val userEmail = ??? // eg "firstname.lastname@guardian.co.uk"
+
+  val has2FA: Boolean = Await.result(checker.check(userEmail), Duration.Inf)
+
+  println(s"User $userEmail has 2FA enabled: $has2FA")
+}
+
+object GoogleCredentialsInDev {
+  /**
+   * Only intended for use by Guardian developers, in development. Requires Janus credentials.
+   */
+  def loadGuardianGoogleCredentials(): GoogleCredentials = {
+    val aws = new AWS("ophan")
+    val serviceAccountCert = aws.loadSecureString("/Ophan/Dashboard/GoogleCloudPlatform/OphanOAuthServiceAccountCert")
+    val impersonatedUser = aws.loadSecureString("/Ophan/Dashboard/GoogleCloudPlatform/ImpersonatedUser")
+
+    ServiceAccountHelper.credentialsFrom(serviceAccountCert).createDelegated(impersonatedUser)
+  }
+}
+
+class AWS(profileName: String) {
+  val credentials: AwsCredentialsProvider = ProfileCredentialsProvider.builder().profileName(profileName).build()
+
+  val SSM: SsmClient =
+    SsmClient.builder().httpClientBuilder(ApacheHttpClient.builder()).credentialsProvider(credentials).region(EU_WEST_1).build()
+
+  def loadSecureString(paramName: String): String = SSM.getParameter(
+    GetParameterRequest.builder().name(paramName).withDecryption(true).build()
+  ).parameter().value()
+}


### PR DESCRIPTION
Checking users have 2FA enabled before they access internal Guardian tools is very important (good security practice, required by GDPR, etc), but in the past it's not been possible to directly check if a user has 2FA enabled - as a proxy, we've checked the user for membership of the `2fa_enforce@guardian.co.uk` Google Group. The Google Group was manually administered, so suffered from reconciliation issues, and Patrick Simkins reports the group does not correspond well with our onboarding process.

Recently, in discussion about this, @andrew-nowak pointed out that we can use Google's Admin SDK Directory API and retrieve the Directory API [`User`](https://developers.google.com/admin-sdk/directory/reference/rest/v1/users#resource:-user) entity, giving access to the `isEnrolledIn2Sv` field which **accurately gives the 2FA status of a user**.

This PR introduces `TwoFactorAuthChecker`, a class that can read the `isEnrolledIn2Sv` field for a given user. If you supply a `TwoFactorAuthChecker` to the `GoogleAuthConfig`, the 2FA status of the user will be checked at authentication time, and rejected if `isEnrolledIn2Sv` is false - only users with 2FA will be allowed to authenticate, and it's no longer necessary, or advisable, to check the `2fa_enforce@guardian.co.uk` Google Group.

#### Required permissions to access the `User` entity

Note that this new call requires the `https://www.googleapis.com/auth/admin.directory.user.readonly` scope, and the Google Service Account used by `TwoFactorAuthChecker` will need to have the corresponding user-read permission set in order for this call to succeed. You can adapt the code in `TwoFactorAuthCheckerCLITester` to double-check permissions are setup correctly.

#### Example PR using this change

* https://github.com/guardian/ophan/pull/5675


#### Similar changes for other Guardian libraries

* https://github.com/guardian/pan-domain-authentication/pull/129
* https://github.com/guardian/cognito-auth-lambdas is the direction we're heading in as a department, to allow ALB-level authentication checks that can be easily deployed via [`@guardian/cdk`](https://github.com/guardian/cdk) - it doesn't support the `isEnrolledIn2Sv` field, yet