### PR TITLE
Prevent Scala Steward breaking com.typesafe.play

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.ignore = [
+  { groupId = "com.typesafe.play" }
+]


### PR DESCRIPTION
Looking at Scala Steward PR https://github.com/guardian/play-googleauth/pull/199, we can see that Scala Steward is [trying to upgrade Play version numbers](https://github.com/guardian/play-googleauth/pull/199/files#r1419066470) in ways that [aren't correct](https://www.playframework.com/documentation/3.0.x/Migration30#Changed-groupId).

This is possibly related to https://github.com/scala-steward-org/scala-steward/pull/3191 & https://github.com/scala-steward-org/scala-steward/pull/3191#discussion_r1395531926

To fix this up, for now we'll ignore Play updates here, as in https://github.com/guardian/play-secret-rotation/commit/607802e387b082de605a27b2097d1e1efd92d3a5
