### PR TITLE
No need to set `sonatypeProjectHosting` with SLRW

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import ReleaseTransformations.*
 import Dependencies.*
 import sbtversionpolicy.withsbtrelease.ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease
-import xerial.sbt.Sonatype.*
 
 name := "play-googleauth"
 
@@ -12,11 +11,7 @@ val artifactPomMetadataSettings = Seq(
 
   description := "Simple Google authentication module for Play 2 & 3",
 
-  licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
-
-  sonatypeProjectHosting :=
-    Some(GitHubHosting("guardian", "play-googleauth", "automated.maven.release.admins@theguardian.com"))
-
+  licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 )
 
 def projectWithPlayVersion(playVersion: PlayVersion) =


### PR DESCRIPTION
The `sonatypeProjectHosting` setting was full of fairly predicatible information that is evident from the repository the code sits in - so we can just let `gha-scala-library-release-workflow` set it for us:

https://github.com/guardian/gha-scala-library-release-workflow/commit/bf9e076faa3520b15ee4a8f1e89ea6e9b253801d

...less config needed per library repo.
