### PR TITLE
Update play-secret-rotation with CSRF fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ def projectWithPlayVersion(playVersion: PlayVersion) =
     Compile / unmanagedSourceDirectories += baseDirectory.value / playVersion.pekkoOrAkkaSrcFolder,
 
     libraryDependencies ++= Seq(
-      "com.gu.play-secret-rotation" %% "core" % "8.1.0",
+      "com.gu.play-secret-rotation" %% "core" % "8.2.0",
       "org.typelevel" %% "cats-core" % "2.10.0",
       commonsCodec,
       "org.scalatest" %% "scalatest" % "3.2.18" % Test,


### PR DESCRIPTION
This updates our version of `play-secret-rotation` to the version that fixes https://github.com/guardian/play-secret-rotation/issues/445 with PR https://github.com/guardian/play-secret-rotation/pull/446.

Re-releasing `play-googleauth` with this update is probably not essential - it looks like the already-released version v6.0.0 of `play-googleauth` works just fine with it, they are not binary-incompatible - but I guess it's nice to have them all compiled against the nicest version of the code.