### PR TITLE
don't reveal internal error details via UI

### DIFF
--- a/play-v29/src/main/scala/com/gu/googleauth/actions.scala
+++ b/play-v29/src/main/scala/com/gu/googleauth/actions.scala
@@ -136,7 +136,7 @@ trait LoginSupport extends Logging {
           case _: Throwable => (e.getClass.getSimpleName, e.getMessage)
         }
         logWarn(desc, e)
-        Future.successful(redirectWithError(failureRedirectTarget, message))
+        Future.successful(redirectWithError(failureRedirectTarget, "Internal error, please check the logs for more information"))
     }.flatMap { userIdentity =>
       authConfig.twoFactorAuthChecker.map(requireTwoFactorAuthFor(userIdentity)).getOrElse(EitherT.pure(userIdentity))
     }


### PR DESCRIPTION
I noticed that we were getting a deserialisation error displayed in the UI.  This is not security best practice to output arbitrary exception information:

[Improper handling of errors can introduce a variety of security problems for a web site. The most common problem is when detailed internal error messages such as stack traces, database dumps, and error codes are displayed to the user (hacker). These messages reveal implementation details that should never be revealed. Such details can provide hackers important clues on potential flaws in the site and such messages are also disturbing to normal users.](https://owasp.org/www-community/Improper_Error_Handling#:~:text=The%20most%20common,to%20normal%20users.)