### PR TITLE
Remove unused `message` val

### DIFF
--- a/play-v29/src/main/scala/com/gu/googleauth/actions.scala
+++ b/play-v29/src/main/scala/com/gu/googleauth/actions.scala
@@ -130,10 +130,9 @@ trait LoginSupport extends Logging {
         logWarn("resend-user-with-expired-anti-forgery-token-to-google", expiredJwt)
         startGoogleLogin()
       case e =>
-        val (desc, message) = e match {
-          case _: IllegalArgumentException => ("anti-forgery-token-invalid", e.getMessage)
-          case _: GoogleAuthException => ("GoogleAuthException", e.getMessage)
-          case _: Throwable => (e.getClass.getSimpleName, e.getMessage)
+        val desc = e match {
+          case _: IllegalArgumentException => "anti-forgery-token-invalid"
+          case _: Throwable => e.getClass.getSimpleName
         }
         logWarn(desc, e)
         Future.successful(redirectWithError(failureRedirectTarget, "Internal error, please check the logs for more information"))


### PR DESCRIPTION
This follows on from https://github.com/guardian/play-googleauth/pull/233 - it turns out the `message` val is now unused, so we can remove it, and simplify the code a little!

PR #233 removed the exception message text from the error displayed to the end user, because the error message text is unconstrained and this corresponds to https://owasp.org/www-community/Improper_Error_Handling .

I was tempted to re-include the `desc` string in the error message displayed to the user, as it is just the string "anti-forgery-token-invalid" or the exception class name, which is more constrained, but re-reading the OWASP doc, this is also discouraged as it's very similar to an error code. (_"internal error messages such as stack traces, database dumps, and error codes"_). When getting error reports in the past, I've found it helpful if they have received an error with a bit more context in it, as surprisingly the error reports often don't include the user that saw the error, or when the error occurred, making it harder to search logs for them! Still, I do appreciate the guidance from OWASP is right.
