### PR TITLE
Temporarily disable compatibility testing as last release failed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val `play-googleauth-root` = (project in file(".")).aggregate(
 ).settings(
   publish / skip := true,
 
-  releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+//  releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,


### PR DESCRIPTION
See here more info: https://github.com/guardian/gha-scala-library-release-workflow/issues/33