### PR TITLE
bump to newly released play-secret-rotation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion.fromAggregatedAssessedComp
 name := "play-googleauth"
 
 ThisBuild / scalaVersion := "2.13.14"
+ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("releases"), // libraries that haven't yet synced to maven central
 
 val artifactPomMetadataSettings = Seq(
   organization := "com.gu.play-googleauth",

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion.fromAggregatedAssessedComp
 name := "play-googleauth"
 
 ThisBuild / scalaVersion := "2.13.14"
-ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("releases"), // libraries that haven't yet synced to maven central
+ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("releases") // libraries that haven't yet synced to maven central
 
 val artifactPomMetadataSettings = Seq(
   organization := "com.gu.play-googleauth",

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ def projectWithPlayVersion(playVersion: PlayVersion) =
     Compile / unmanagedSourceDirectories += baseDirectory.value / playVersion.pekkoOrAkkaSrcFolder,
 
     libraryDependencies ++= Seq(
-      "com.gu.play-secret-rotation" %% "core" % "8.3.1",
+      "com.gu.play-secret-rotation" %% "core" % "8.4.5",
       "org.typelevel" %% "cats-core" % "2.10.0",
       commonsCodec,
       "org.scalatest" %% "scalatest" % "3.2.18" % Test,


### PR DESCRIPTION
Co-authored-by: @rtyley

brings in the release https://github.com/guardian/play-secret-rotation/releases/tag/v8.4.5