### PR TITLE
Avoid deprecated `jjwt` methods for signing & parsing

### DIFF
--- a/play-v29/src/test/scala/com/gu/googleauth/AntiForgeryCheckerTest.scala
+++ b/play-v29/src/test/scala/com/gu/googleauth/AntiForgeryCheckerTest.scala
@@ -2,7 +2,8 @@ package com.gu.googleauth
 
 import com.gu.play.secretrotation.DualSecretTransition.{InitialSecret, TransitioningSecret}
 import io.jsonwebtoken.SignatureAlgorithm.{HS256, HS384}
-import io.jsonwebtoken.{ExpiredJwtException, SignatureException, UnsupportedJwtException}
+import io.jsonwebtoken.security.SignatureException
+import io.jsonwebtoken.{ExpiredJwtException, UnsupportedJwtException}
 import org.scalatest.TryValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
[`jjwt`](https://github.com/jwtk/jjwt) is a library for creating and verifying [JSON Web Tokens](https://jwt.io/introduction) (JWTs), which we've used directly in `play-googleauth` for the `AntiForgeryChecker` since PR https://github.com/guardian/play-googleauth/pull/52 in January 2018.

### Deprecations in `jjwt`

* `signWith()` & `setSigningKey()` now prefer to be given a `Key` type rather than a base64-encoded String - deprecated in https://github.com/jwtk/jjwt/pull/341
* To obtain a configured `JwtParser`, a builder is now preferred, ie `Jwts.parserBuilder().setSigningKey(key).build()` rather than `Jwts.parser().setSigningKey(key)` - deprecated in https://github.com/jwtk/jjwt/pull/486
* Use `io.jsonwebtoken.security.SignatureException` rather than `io.jsonwebtoken.SignatureException` - deprecated in https://github.com/jwtk/jjwt/pull/367

### Supporting all required versions of `jjwt`

Note that `play-googleauth` currently supports two versions of Play, but they both use the same version of `jjwt`:

* Play v2.9, [uses](https://github.com/playframework/playframework/blob/fafc04336aec2dcb6e352d81c67f5fdb424d3b71/project/Dependencies.scala#L75) jjwt v0.11.5
* Play v3.0, [uses](https://github.com/playframework/playframework/blob/3c8156e8aeb6d337e30053706880c59dd4a5ea98/project/Dependencies.scala#L91) jjwt v0.11.5

...the newer 'dev' versions of Play are [using](https://github.com/playframework/playframework/blob/7abd258b925c80594afa47739edbcc356490c853/project/Dependencies.scala#L75) newer versions of `jjwt`.
