### PR TITLE
Bump sbt version to 1.10.1

### DIFF
--- a/play-v29/src/sbt-test/example/webapp/project/build.properties
+++ b/play-v29/src/sbt-test/example/webapp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+../../../../../../project/build.properties

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.1


### PR DESCRIPTION
## What does this change?
* Bumping sbt to the latest version
* We're now using a symbolic link for the sbt version of the subprojects

## Why?
sbt 1.1.6 isn't recent enough for Snyk: https://chat.google.com/room/AAAAag0I08g/fFGcXFskQKk/7O5BVztqn3w?cls=12. We expect this to fix this job: https://github.com/guardian/play-googleauth/actions/runs/9891177854
