### PR TITLE
Upgrade example app to work with latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,24 @@ on:
       - main
 
 jobs:
-  sbt-build:
+  test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/cache-action@v6
-      - uses: olafurpg/setup-scala@v11
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: corretto
+          java-version: 21
+          cache: sbt
       - name: Build and Test
-        run: sbt ++test
+        run: sbt -v +test publishLocal
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "test-results/**/TEST-*.xml"
+        if: always()
+      - name: Integration Test
+        working-directory: ./play-v30/src/sbt-test/example/webapp
+        run: sbt -v compile

--- a/play-v29/src/sbt-test/example/webapp/app/controllers/Application.scala
+++ b/play-v29/src/sbt-test/example/webapp/app/controllers/Application.scala
@@ -4,7 +4,6 @@ import com.gu.googleauth
 import com.gu.googleauth.{AuthAction, Filters, GoogleAuthConfig, GoogleGroupChecker}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
-import com.google.api.client.auth.oauth2.GoogleCredential
 
 import scala.concurrent.ExecutionContext
 

--- a/play-v29/src/sbt-test/example/webapp/app/controllers/Login.scala
+++ b/play-v29/src/sbt-test/example/webapp/app/controllers/Login.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.googleauth.{GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount, LoginSupport}
+import com.gu.googleauth.{GoogleAuthConfig, GoogleGroupChecker, LoginSupport}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
@@ -38,9 +38,9 @@ class Login(requiredGoogleGroups: Set[String], val authConfig: GoogleAuthConfig,
   }
 
   def logout = Action { implicit request =>
-    Redirect(routes.Application.index()).withNewSession
+    Redirect(routes.Application.index).withNewSession
   }
 
-  override val failureRedirectTarget: Call = routes.Login.login()
-  override val defaultRedirectTarget: Call = routes.Application.authenticated()
+  override val failureRedirectTarget: Call = routes.Login.login
+  override val defaultRedirectTarget: Call = routes.Application.authenticated
 }

--- a/play-v29/src/sbt-test/example/webapp/app/views/authenticated.scala.html
+++ b/play-v29/src/sbt-test/example/webapp/app/views/authenticated.scala.html
@@ -18,7 +18,7 @@
             <p><img class="avatar" src="@avatarUrl" alt="@request.user.firstName" /></p>
         }
         <p>The expiry time is @{Instant.ofEpochSecond(request.user.exp)}</p>
-        <p>You can go to the <a href="@routes.Login.login()">login page</a>
-            or <a href="@routes.Login.logout()">logout</a>.</p>
+        <p>You can go to the <a href="@routes.Login.login">login page</a>
+            or <a href="@routes.Login.logout">logout</a>.</p>
     </body>
 </html>

--- a/play-v29/src/sbt-test/example/webapp/app/views/index.scala.html
+++ b/play-v29/src/sbt-test/example/webapp/app/views/index.scala.html
@@ -5,8 +5,8 @@
     <body>
         <h1>Home page</h1>
         <p>This is the home page of the example application.</p>
-        <p>You can go to the <a href="@routes.Login.login()">login page</a>,
-            a <a href="@routes.Application.authenticated()">page that requires authentication</a>,
-            or <a href="@routes.Login.logout()">logout</a>.</p>
+        <p>You can go to the <a href="@routes.Login.login">login page</a>,
+            a <a href="@routes.Application.authenticated">page that requires authentication</a>,
+            or <a href="@routes.Login.logout">logout</a>.</p>
     </body>
 </html>

--- a/play-v29/src/sbt-test/example/webapp/app/views/login.scala.html
+++ b/play-v29/src/sbt-test/example/webapp/app/views/login.scala.html
@@ -9,10 +9,10 @@
         @error.map { message =>
             <p>The error was: @message</p>
         }
-        <form action="@routes.Login.loginAction()" method="get">
+        <form action="@routes.Login.loginAction" method="get">
             <input value="Log In" type="submit">
         </form>
-        <p>You can also go to a <a href="@routes.Application.authenticated()">page that requires authentication</a>
-            or <a href="@routes.Login.logout()">logout</a>.</p>
+        <p>You can also go to a <a href="@routes.Application.authenticated">page that requires authentication</a>
+            or <a href="@routes.Login.logout">logout</a>.</p>
     </body>
 </html>

--- a/play-v29/src/sbt-test/example/webapp/build.sbt
+++ b/play-v29/src/sbt-test/example/webapp/build.sbt
@@ -1,9 +1,9 @@
 name := "play-googleauth-example"
 
-scalaVersion := "2.12.16"
+scalaVersion := "2.13.14"
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "play-googleauth" % version.value,
+  "com.gu.play-googleauth" %% "play-v30" % version.value,
   ws
 )
 

--- a/play-v29/src/sbt-test/example/webapp/project/plugins.sbt
+++ b/play-v29/src/sbt-test/example/webapp/project/plugins.sbt
@@ -1,5 +1,2 @@
-// The Typesafe repository
-resolvers += Resolver.typesafeIvyRepo("releases")
-
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.17")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.4")

--- a/play-v29/src/sbt-test/example/webapp/version.sbt
+++ b/play-v29/src/sbt-test/example/webapp/version.sbt
@@ -1,1 +1,1 @@
-../../../../version.sbt
+../../../../../version.sbt


### PR DESCRIPTION
We've updated the example app, as part of an effort to see if we could get Snyk to work again (Snyk was attempting to build the inner example app, not just the top-level project) - but Snyk will probably continue to fail, as the inner example app depends on a snapshot release of play-googleauth that needs to be locally published.

We're going to switch to GHAS with https://github.com/guardian/play-googleauth/pull/243 anyway, so will take the example app fixes, but not worry too much about Snyk being broke.