### PR TITLE
Fix failing CI due to sbt not found error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 21
-          cache: sbt
+
+      - uses: guardian/setup-scala@v1
+
       - name: Build and Test
         run: sbt -v +test publishLocal
       - name: Test Summary


### PR DESCRIPTION
See more at: https://github.com/guardian/redirect-resolver/pull/24

## How to test

Observe CI on this PR

## How can we measure success?

CI should run successfully
