### PR TITLE
Cache results of group checker

### DIFF
--- a/play-v29/src/main/scala/com/gu/googleauth/groups.scala
+++ b/play-v29/src/main/scala/com/gu/googleauth/groups.scala
@@ -3,8 +3,10 @@ package com.gu.googleauth
 import com.google.api.services.directory.Directory
 import com.google.api.services.directory.DirectoryScopes.ADMIN_DIRECTORY_GROUP_READONLY
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
+import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import com.gu.googleauth.internal.DirectoryService
 
+import java.time.Duration
 import scala.concurrent._
 import scala.jdk.CollectionConverters._
 
@@ -23,15 +25,38 @@ import scala.jdk.CollectionConverters._
  *
  * @param impersonatedUser a separate domain-user account email address (eg 'example@guardian.co.uk'), the email address
  *                         of the user the application will be impersonating when making calls.
+ * @param serviceAccountCredentials Google OAuth2 credentials.
+ * @param cacheDuration how long to cache each user's groups for (defaults to 1 minute).
+ *
  */
-class GoogleGroupChecker(impersonatedUser: String, serviceAccountCredentials: ServiceAccountCredentials) {
+class GoogleGroupChecker(
+  impersonatedUser: String,
+  serviceAccountCredentials: ServiceAccountCredentials,
+  cacheDuration: Duration = Duration.ofMinutes(1)
+) {
 
   private val googleCredentials: GoogleCredentials = serviceAccountCredentials.createDelegated(impersonatedUser)
 
   private val directoryService: Directory = DirectoryService(googleCredentials, ADMIN_DIRECTORY_GROUP_READONLY)
 
-  def retrieveGroupsFor(userEmail: String)(implicit ec: ExecutionContext): Future[Set[String]] = for {
-    resp <- Future { blocking { directoryService.groups.list.setUserKey(userEmail).execute() } }
-  } yield resp.getGroups.asScala.map(_.getEmail).toSet
-  
+  type Email = String
+  private val cache: LoadingCache[Email, Set[String]] = CacheBuilder.newBuilder()
+    .expireAfterWrite(cacheDuration)
+    .build(
+      new CacheLoader[Email, Set[String]]() {
+        def load(email: Email): Set[String] = {
+          println(s"loading $email")
+          val result = directoryService.groups.list.setUserKey(email).execute()
+          result.getGroups.asScala.map(_.getEmail).toSet
+        }
+      }
+    )
+
+  def retrieveGroupsFor(userEmail: String)(implicit ec: ExecutionContext): Future[Set[String]] = Future {
+    val start = System.currentTimeMillis()
+    val result = blocking { cache.get(userEmail) }
+    val end = System.currentTimeMillis()
+    println(s"took ${end - start}")
+    result
+  }
 }

--- a/play-v29/src/main/scala/com/gu/googleauth/groups.scala
+++ b/play-v29/src/main/scala/com/gu/googleauth/groups.scala
@@ -45,7 +45,6 @@ class GoogleGroupChecker(
     .build(
       new CacheLoader[Email, Set[String]]() {
         def load(email: Email): Set[String] = {
-          println(s"loading $email")
           val result = directoryService.groups.list.setUserKey(email).execute()
           result.getGroups.asScala.map(_.getEmail).toSet
         }
@@ -53,10 +52,6 @@ class GoogleGroupChecker(
     )
 
   def retrieveGroupsFor(userEmail: String)(implicit ec: ExecutionContext): Future[Set[String]] = Future {
-    val start = System.currentTimeMillis()
-    val result = blocking { cache.get(userEmail) }
-    val end = System.currentTimeMillis()
-    println(s"took ${end - start}")
-    result
+    blocking { cache.get(userEmail) }
   }
 }

--- a/play-v29/src/main/scala/com/gu/googleauth/groups.scala
+++ b/play-v29/src/main/scala/com/gu/googleauth/groups.scala
@@ -44,6 +44,7 @@ class GoogleGroupChecker(
     .expireAfterWrite(cacheDuration)
     .build(
       new CacheLoader[Email, Set[String]]() {
+        // If the loading function throws then nothing is cached, and calls to cache.get() also throw
         def load(email: Email): Set[String] = {
           val result = directoryService.groups.list.setUserKey(email).execute()
           result.getGroups.asScala.map(_.getEmail).toSet


### PR DESCRIPTION
The `GoogleGroupChecker` class makes requests to the Google directory service to find each user's groups.

Currently if the `requireGroup` Filter is used to check group memberships, a request is made to the Google API every time. I have found that these requests can take ~600ms each time, which can really add up if a webapp needs to make multiple requests, or if the `requireGroup` Filter is chained.

This PR introduces a cache to the `GoogleGroupChecker` class to reduce the number of calls to the Google directory. The cache duration is now a class parameter, and defaults to 1 minute.
Note - I've used Google's guava cache here because it's already available in this library.