### PR TITLE
revert back to v23 so that we can retry the failed release

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "24.0.1-SNAPSHOT"
+ThisBuild / version := "23.0.1-SNAPSHOT"


### PR DESCRIPTION
This release failed https://github.com/guardian/play-googleauth/actions/runs/14858933594
which caused subsequent ones to fail with an error determining the version.

This PR reverts the version change so that we can try releasing v24 again.

I have also deleted the "release" and "tag" using GH ui.