### PR TITLE
CVE-2025-52999: Force Play to use a newer version of Jackson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion.fromAggregatedAssessedComp
 name := "play-googleauth"
 
 ThisBuild / scalaVersion := "2.13.16"
-ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("releases") // libraries that haven't yet synced to maven central
 
 val artifactPomMetadataSettings = Seq(
   organization := "com.gu.play-googleauth",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
       val playWS = groupId %% "play-ws" % exactPlayVersion % Provided
       val playTest = groupId %% "play-test" % exactPlayVersion % Test
 
-      Seq(play, playWS, playTest)
+      Seq(play, playWS, playTest, jackson)
     }
 
     val pekkoOrAkkaSrcFolder = s"src-${if (usesPekko) "pekko" else "akka"}"
@@ -48,5 +48,8 @@ object Dependencies {
     "com.google.api-client" % "google-api-client" % "2.8.0",
     "com.google.auth" % "google-auth-library-oauth2-http" % "1.37.0"
   ).map(_ exclude("com.google.guava", "guava-jdk5")) :+ "com.google.guava" % "guava" % "33.4.8-jre"
+
+  // Play 2.9 & 3.0 are stuck on Jackson 2.14, which has 'high' vulnerabilities
+  val jackson = "com.fasterxml.jackson.core" % "jackson-core" % "2.19.1"
 
 }


### PR DESCRIPTION
Fixing https://github.com/guardian/play-googleauth/security/dependabot/12.

GHSA-h46c-h94j-95f3
CVE-2025-52999

There's no version of Play that is compiled against Jackson 2.15 - we would need to wait for Play 3.1 for that.

After discussion with DevX, we've confirmed that our policy that we treat labelling of repositories as 'production' the same whether they are app repos or library repos - so long as the code runs in Production at the Guardian, it should be labelled 'production', and have the same SLAs.