### PR TITLE
Use `setup-scala`

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -11,15 +11,7 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: Install Java
-        id: java
-        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
-        with:
-          distribution: corretto
-          java-version: 17
-      - name: Install sbt
-        id: sbt
-        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+      - uses: guardian/setup-scala@v1
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-11.0.22.7.1
+java corretto-21.0.3.9.1


### PR DESCRIPTION
This is more concise - https://github.com/guardian/setup-scala combines [setup-java](https://github.com/actions/setup-java) & [setup-sbt](https://github.com/sbt/setup-sbt) with good defaults for the Guardian.


