### PR TITLE
Change play dependencies to Compile scope

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ object Dependencies {
 
     val playLibs: Seq[ModuleID] = {
 
-      val play = groupId %% "play" % exactPlayVersion % Provided
-      val playWS = groupId %% "play-ws" % exactPlayVersion % Provided
+      val play = groupId %% "play" % exactPlayVersion
+      val playWS = groupId %% "play-ws" % exactPlayVersion
       val playTest = groupId %% "play-test" % exactPlayVersion % Test
 
       Seq(play, playWS, playTest, jackson)


### PR DESCRIPTION
## What does this change?

This library’s dependencies on play were marked as using [Provided scope](https://www.baeldung.com/maven-dependency-scopes#2-provided), which seems to have interacted poorly with our dependency vulnerability tracking. Even though we recently [added an override to avoid a jackson vulnerability](https://github.com/guardian/play-googleauth/pull/308), the older version of jackson was still reported by the sbt-dependency-graph workflow to the dependency graph on github. (Meaning the project incorrectly (we think) continued to show as vulnerable on our vulnerability dashboard.)

This commit changes these to the default Compile scope, which should let our dashboard show us what we expect. It will have a slightly different behaviour for consumers of the library, where this library’s dependency on Play might now evict the consumer’s, but we think this is better than the current situation. In general we have found [Provided scope dependencies are confusing](https://github.com/guardian/maintaining-scala-projects/issues/19).

## How to test

We could create a preview release and test it in one of our apps that consumes this library, but we think that’s probably overkill for this change.

## How can we measure success?

- fewer vulnerabilities in our dashboard
