### PR TITLE
Remove sbt-sonatype plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
-
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")


### PR DESCRIPTION
With the update to `gha-scala-library-release-workflow` v2 made by dependabot:

* https://github.com/guardian/play-googleauth/pull/312

...we can remove the `sbt-sonatype` plugin, thanks to:

* https://github.com/guardian/gha-scala-library-release-workflow/pull/62

...it's a shame we can't get dependabot to automate this with its PRs!
