### PR TITLE
Introduce variable for jjwt versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ val artifactPomMetadataSettings = Seq(
   description := "Simple Google authentication module for the Play web framework"
 )
 
+val jjwtVersion = "0.12.7"
+
 def projectWithPlayVersion(playVersion: PlayVersion) =
   Project(playVersion.projectId, file(playVersion.projectId)).settings(
     crossScalaVersions := Seq(scalaVersion.value, "3.3.7"),
@@ -20,9 +22,9 @@ def projectWithPlayVersion(playVersion: PlayVersion) =
     libraryDependencies ++= Seq(
       "com.gu.play-secret-rotation" %% "core" % "17.0.3",
       "org.typelevel" %% "cats-core" % "2.13.0",
-      "io.jsonwebtoken" % "jjwt-api" % "0.12.7",
-      "io.jsonwebtoken" % "jjwt-impl" % "0.12.7",
-      "io.jsonwebtoken" % "jjwt-jackson" % "0.12.7",
+      "io.jsonwebtoken" % "jjwt-api" % jjwtVersion,
+      "io.jsonwebtoken" % "jjwt-impl" % jjwtVersion,
+      "io.jsonwebtoken" % "jjwt-jackson" % jjwtVersion,
       commonsCodec,
       "org.scalatest" %% "scalatest" % "3.2.20" % Test,
       "software.amazon.awssdk" % "ssm" % "2.41.34" % Test


### PR DESCRIPTION
## What does this change?

I don’t think these version should be allowed to differ. They were introduced in https://github.com/guardian/play-googleauth/pull/392 at 0.12.6, and then Scala Steward raised https://github.com/guardian/play-googleauth/pull/394 which updated only two of the versions (rather than all three).

I don’t think they were deliberately kept separate, and from looking at the project I think these versions should be in sync.

Using this variable will hopefully prevent them drifting.

## How has this change been tested?

If CI passes this should be ok to merge, because the build should be unaffected.