### PR TITLE
Remove guava override

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,7 +43,7 @@ object Dependencies {
     "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20260227-2.0.0",
     "com.google.api-client" % "google-api-client" % "2.9.0",
     "com.google.auth" % "google-auth-library-oauth2-http" % "1.46.0"
-  ).map(_ exclude("com.google.guava", "guava-jdk5")) :+ "com.google.guava" % "guava" % "33.6.0-jre"
+  )
 
   // Play 3.0 is stuck on Jackson 2.14, which has 'high' vulnerabilities
   val jackson = "com.fasterxml.jackson.core" % "jackson-core" % "2.21.2"


### PR DESCRIPTION
In [2016 a change](https://github.com/guardian/play-googleauth/pull/37) was made to remove the `guava-jdk5` transitive dependency from the google dependencies, and instead use the regular `com.google.guava:guava` dependency.

This override no longer appears to be necessary as these google dependencies are no longer pulling in `guava-jdk`.

Note - with this change it now pulls in `com.google.guava:guava:33.5.0-android`, instead of `com.google.guava:guava:33.6.0-jre`.

<img width="1405" height="101" alt="Screenshot 2026-04-23 at 11 56 53" src="https://github.com/user-attachments/assets/8c938ee5-f368-48f6-ab1a-dea5d64d1283" />
